### PR TITLE
Add PIN-based encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+trussed-state.bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,5 +70,5 @@ required-features = ["ctaphid", "devel"]
 
 [patch.crates-io]
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
-trussed = { git = "https://github.com/Nitrokey/trussed", rev = "refs/pull/14/head" }
+trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.7" }
 littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,12 @@ devel-ctaphid-bug = []
 # Allow to use application over CTAPHID interface
 ctaphid = ["ctaphid-dispatch"]
 
+# Set the default files location to the internal memory. Useful for debugging.
+devel-location-internal = []
+
+# Enable challenge-response method (only authentication, does not encrypt data)
+challenge-response-auth = []
+
 log-all = []
 log-none = []
 log-info = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,4 +70,5 @@ required-features = ["ctaphid", "devel"]
 
 [patch.crates-io]
 flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey" }
-trussed = { git = "https://github.com/trussed-dev/trussed/", rev = "refs/pull/102/head" }
+trussed = { git = " https://github.com/Nitrokey/trussed//", rev = "refs/pull/14/head" }
+littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ serde = { version = "1", default-features = false }
 trussed = { version = "0.1", features = ["clients-3"] }
 encrypted_container = { path = "components/encrypted_container" }
 
+# extension
+trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "refs/pull/10/head" }
+
 [dev-dependencies]
 log = { version = "0.4.14", default-features = false }
 pretty_env_logger = "0.4.0"
@@ -33,9 +36,6 @@ clap-num = "1.0.0"
 delog = { version = "0.1.6", features = ["std-log"] }
 fido-authenticator = { version = "0.1", features = ["dispatch", "log-all"] }
 admin-app = { version = "0.1", features = ["log-all"] }
-
-# backend
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "refs/pull/10/head" }
 
 [features]
 default = ["apdu-dispatch"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ trussed = { version = "0.1", features = ["clients-3"] }
 encrypted_container = { path = "components/encrypted_container" }
 
 # extension
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "refs/pull/10/head" }
+trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "5962c7526d2a1f8c339dfdb14324ab44d55738f7" }
 
 [dev-dependencies]
 log = { version = "0.4.14", default-features = false }
@@ -70,8 +70,5 @@ required-features = ["ctaphid", "devel"]
 
 [patch.crates-io]
 flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey" }
-#littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
 littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
-#trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
-#trussed = { git = "https://github.com/trussed-dev/trussed/", rev = "refs/pull/102/head" }
 trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey-5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ trussed = { version = "0.1", features = ["clients-3"] }
 encrypted_container = { path = "components/encrypted_container" }
 
 # extension
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "refs/pull/10/head" }
+trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", tag = "v0.1.0" }
 
 [dev-dependencies]
 log = { version = "0.4.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,9 +50,6 @@ devel-ctaphid-bug = []
 # Allow to use application over CTAPHID interface
 ctaphid = ["ctaphid-dispatch"]
 
-# Set the default files location to the internal memory. Useful for debugging.
-devel-location-internal = []
-
 # Enable challenge-response method (only authentication, does not encrypt data)
 challenge-response-auth = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,6 @@ required-features = ["ctaphid", "devel"]
 
 
 [patch.crates-io]
-flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey" }
-trussed = { git = " https://github.com/Nitrokey/trussed//", rev = "refs/pull/14/head" }
+flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
+trussed = { git = "https://github.com/Nitrokey/trussed", rev = "refs/pull/14/head" }
 littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ delog = { version = "0.1.6", features = ["std-log"] }
 fido-authenticator = { version = "0.1", features = ["dispatch", "log-all"] }
 admin-app = { version = "0.1", features = ["log-all"] }
 
+# backend
+trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "refs/pull/10/head" }
 
 [features]
 default = ["apdu-dispatch"]
@@ -68,5 +70,8 @@ required-features = ["ctaphid", "devel"]
 
 [patch.crates-io]
 flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey" }
-littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
-trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
+#littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
+littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
+#trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
+#trussed = { git = "https://github.com/trussed-dev/trussed/", rev = "refs/pull/102/head" }
+trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey-5" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,5 +70,4 @@ required-features = ["ctaphid", "devel"]
 
 [patch.crates-io]
 flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey" }
-littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
-trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey-5" }
+trussed = { git = "https://github.com/trussed-dev/trussed/", rev = "refs/pull/102/head" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4.14", default-features = false }
 pretty_env_logger = "0.4.0"
 
 # below are for running the usbip example
-trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ctaphid"], rev = "5da7c880a5be8f23599dc561643039ea4eae1ead" }
+trussed-usbip = { git = "https://github.com/trussed-dev/pc-usbip-runner", default-features = false, features = ["ctaphid"], rev = "f3a680ca4c9a1411838ae0774f1713f79d4c2979" }
 usbd-ctaphid = "0.1"
 clap = { version = "3.0.0", features = ["cargo", "derive"] }
 clap-num = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ devel-location-internal = []
 # Enable challenge-response method (only authentication, does not encrypt data)
 challenge-response-auth = []
 
+# Enable oath calculate-all command
+calculate-all = []
+
 log-all = []
 log-none = []
 log-info = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ trussed = { version = "0.1", features = ["clients-3"] }
 encrypted_container = { path = "components/encrypted_container" }
 
 # extension
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "5962c7526d2a1f8c339dfdb14324ab44d55738f7" }
+trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "refs/pull/10/head" }
 
 [dev-dependencies]
 log = { version = "0.4.14", default-features = false }

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,97 @@
+APPNAME=udp_sim
+FLAGS=--features=enable-logs
+
+all: | start-sim attach finish-message
+
+.PHONY: finish-message
+finish-message:
+	@echo "###################################################"
+	@echo "Done. Device should be visible in your system now. Run 'make stop' to disconnect it."
+
+.PHONY: start-sim
+start-sim: $(APPNAME)
+	-$(MAKE) stop
+	env RUST_LOG=info RUST_BACKTRACE=1 cargo run $(FLAGS) &
+	sleep 1
+
+.PHONY: autoattach
+autoattach:
+	 while true; do $(MAKE) attach; sleep 1; inotifywait ${CARGO_TARGET_DIR}/debug/usbip-simulation; sleep 5; done;
+
+.PHONY: attach
+attach: 
+	lsmod | grep vhci-hcd || sudo modprobe vhci-hcd
+	sudo usbip list -r "localhost"
+	sudo usbip attach -r "localhost" -b "1-1"
+	sudo usbip attach -r "localhost" -b "1-1"
+	sleep 5
+	-notify-send 'Webcrypt USB/IP' 'Attached'
+
+
+.PHONY: ci
+ci:
+	timeout 10 -k 5 $(MAKE)
+
+.PHONY: build
+build: $(APPNAME)
+
+.PHONY: build-clean
+build-clean: | clean build
+
+.PHONY: $(APPNAME)
+$(APPNAME):
+	 cargo build $(FLAGS)
+
+.PHONY: stop
+stop:
+	-sudo usbip detach -p "00"
+	killall $(APPNAME) usbip-simulation
+
+.PHONY: setup-fedora
+setup-fedora:
+	sudo dnf install usbip
+	sudo dnf install fuse-devel
+	sudo dnf install clang-libs-13.0.0
+	sudo ln -s /usr/lib64/libclang.so.13 /usr/lib64/libclang.so
+
+.PHONY: clean
+clean:
+	cargo clean
+	rm $(APPNAME) -v
+
+.PHONY: build-docker
+CMD=make -C /app/runners/pc-usbip/ build
+build-docker:
+	docker build -t usbip .
+	mkdir -p cargo-cache
+	docker run -it --rm -v $(PWD)/cargo-cache:/root/.cargo -v $(PWD)/../../:/app usbip $(CMD)
+	touch $(APPNAME)
+
+
+LFS=./tmp/littlefs-fuse/lfs
+$(LFS):
+	mkdir -p tmp
+	-cd tmp && git clone https://github.com/littlefs-project/littlefs-fuse
+	cd tmp/littlefs-fuse && make
+
+fs=./trussed-state.bin
+mount=/tmp/mnt/bee
+state=mount.state
+
+.PHONY: mount umount
+mount: $(LFS)
+	# https://github.com/littlefs-project/littlefs-fuse#usage-on-linux
+	mkdir -p $(mount)
+	lsmod | grep loop || sudo modprobe loop
+	sudo losetup --find --show $(fs) | tee loop.dev
+	grep "/dev/loop" loop.dev && sudo chmod a+rw `cat loop.dev`
+	$(LFS) --block_count=128 `cat loop.dev` $(mount)
+	printf "loop_device=`cat loop.dev`\nmount=$(mount)" > $(state)
+	tree -C -h $(mount)
+
+umount:
+	-umount $(mount)
+	sudo losetup -d `cat loop.dev`
+	rm ./$(state)
+
+

--- a/examples/usbip.rs
+++ b/examples/usbip.rs
@@ -239,14 +239,6 @@ struct Apps {
     otp: oath_authenticator::Authenticator<VirtClient>,
 }
 
-struct ClientBuilderImpl {}
-
-impl ClientBuilder<VirtClient, dispatch::Dispatch> for ClientBuilderImpl {
-    fn build(&self, _id: &str, _backends: &'static [BackendId<dispatch::Backend>]) -> VirtClient {
-        todo!()
-    }
-}
-
 impl trussed_usbip::Apps<VirtClient, dispatch::Dispatch> for Apps {
     type Data = ();
     fn new<B: ClientBuilder<VirtClient, dispatch::Dispatch>>(builder: &B, _data: ()) -> Self {

--- a/examples/usbip.rs
+++ b/examples/usbip.rs
@@ -123,10 +123,9 @@ use clap_num::maybe_hex;
 use log::info;
 use trussed::backend::BackendId;
 use trussed::platform::{consent, reboot, ui};
-use trussed::{virt, Client, ClientImplementation, Platform, Service};
+use trussed::{virt, ClientImplementation, Platform};
 use trussed_usbip::ClientBuilder;
 
-use fido_authenticator::TrussedRequirements;
 use usbd_ctaphid::constants::MESSAGE_SIZE;
 
 pub type FidoConfig = fido_authenticator::Config;
@@ -243,7 +242,7 @@ struct Apps {
 struct ClientBuilderImpl {}
 
 impl ClientBuilder<VirtClient, dispatch::Dispatch> for ClientBuilderImpl {
-    fn build(&self, id: &str, backends: &'static [BackendId<dispatch::Backend>]) -> VirtClient {
+    fn build(&self, _id: &str, _backends: &'static [BackendId<dispatch::Backend>]) -> VirtClient {
         todo!()
     }
 }

--- a/examples/usbip.rs
+++ b/examples/usbip.rs
@@ -120,7 +120,7 @@ use apdu_dispatch::command::SIZE as ApduCommandSize;
 
 use clap::Parser;
 use clap_num::maybe_hex;
-use log::info;
+use log::{debug, info};
 use trussed::backend::BackendId;
 use trussed::platform::{consent, reboot, ui};
 use trussed::{virt, ClientImplementation, Platform};
@@ -214,7 +214,7 @@ impl trussed::platform::UserInterface for UserInterface {
     }
 
     fn set_status(&mut self, status: ui::Status) {
-        info!("Set status: {:?}", status);
+        debug!("Set status: {:?}", status);
 
         if status == ui::Status::WaitingForUserPresence {
             info!(">>>> Received confirmation request. Confirming automatically.");

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -107,8 +107,6 @@ struct AnswerToSelect {
 struct PINAnswerToSelect {
     #[tlv(simple = "0x79")] // Tag::Version
     version: OathVersion,
-    #[tlv(simple = "0x71")] // Tag::Name
-    salt: [u8; 8],
 
     #[tlv(simple = "0x82")] // Tag::PINCounter
     attempt_counter: Option<[u8; 1]>,
@@ -150,7 +148,6 @@ impl AnswerToSelect {
         let c = counter.map(u8::to_be_bytes);
         PINAnswerToSelect {
             version: self.version,
-            salt: self.salt,
             attempt_counter: c,
         }
     }
@@ -307,10 +304,6 @@ where
         let answer_to_select = AnswerToSelect::new(state.salt);
 
         let data: heapless::Vec<u8, 128> = if self._extension_is_pin_set() {
-            answer_to_select
-                .with_challenge(self.state.runtime.challenge)
-                .to_heapless_vec()
-        } else if self._extension_is_pin_set() {
             answer_to_select
                 .with_pin_attempt_counter(self._extension_attempt_counter())
                 .to_heapless_vec()

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -5,10 +5,8 @@ use flexiber::{Encodable, EncodableHeapless};
 use heapless_bytes::Bytes;
 use iso7816::{Data, Status};
 use trussed::types::KeyId;
-use trussed::{client, syscall, try_syscall, types::PathBuf};
-
-#[allow(unused)]
 use trussed::types::Location;
+use trussed::{client, syscall, try_syscall, types::PathBuf};
 
 use crate::command::VerifyCode;
 use crate::credential::Credential;

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1046,7 +1046,7 @@ where
     }
 
     fn _extension_pin_factory_reset(&mut self) -> Result {
-        try_syscall!(self.trussed.delete_pin(BACKEND_USER_PIN_ID))
+        try_syscall!(self.trussed.delete_all_pins())
             .map_err(|_| iso7816::Status::UnspecifiedNonpersistentExecutionError)?;
         Ok(())
     }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -6,6 +6,9 @@ use heapless_bytes::Bytes;
 use iso7816::{Data, Status};
 use trussed::{client, syscall, try_syscall, types::PathBuf};
 
+#[allow(unused)]
+use trussed::types::Location;
+
 use crate::command::VerifyCode;
 use crate::credential::Credential;
 use crate::oath::Kind;

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -305,7 +305,7 @@ where
             .with_persistent(&mut self.trussed, |_, state| state.clone());
         let answer_to_select = AnswerToSelect::new(state.salt);
 
-        let data: heapless::Vec<u8, 128> = if state.password_set() {
+        let data: heapless::Vec<u8, 128> = if self._extension_is_pin_set() {
             answer_to_select
                 .with_challenge(self.state.runtime.challenge)
                 .to_heapless_vec()

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -155,6 +155,7 @@ impl AnswerToSelect {
     /// This challenge is only added when a password is set on the device.
     ///
     /// It is rotated each time SELECT is called.
+    #[cfg(feature = "challenge-response-auth")]
     fn with_challenge(self, challenge: [u8; 8]) -> ChallengingAnswerToSelect {
         ChallengingAnswerToSelect {
             version: self.version,
@@ -253,6 +254,7 @@ where
         if !self.state.runtime.client_authorized {
             match command {
                 Command::Select(_) => {}
+                #[cfg(feature = "challenge-response-auth")]
                 Command::Validate(_) => {}
                 Command::Reset => {}
                 Command::VerifyCode(_) => {}

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1081,8 +1081,15 @@ where
     }
 
     fn _extension_change_pin(&mut self, password: &[u8], new_password: &[u8]) -> Result {
-        self._extension_check_pin(password)?;
-        self._extension_set_pin(new_password)?;
+        let r = try_syscall!(self.trussed.change_pin(
+            BACKEND_USER_PIN_ID,
+            Bytes::from_slice(password).map_err(|_| iso7816::Status::IncorrectDataParameter)?,
+            Bytes::from_slice(new_password).map_err(|_| iso7816::Status::IncorrectDataParameter)?,
+        ))
+        .map_err(|_| iso7816::Status::UnspecifiedNonpersistentExecutionError)?;
+        if !r.success {
+            return Err(iso7816::Status::VerificationFailed);
+        }
         Ok(())
     }
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1080,7 +1080,7 @@ where
         Ok(())
     }
 
-    fn _extension_change_pin<'l>(&mut self, password: &'l [u8], new_password: &'l [u8]) -> Result {
+    fn _extension_change_pin(&mut self, password: &[u8], new_password: &[u8]) -> Result {
         self._extension_check_pin(password)?;
         self._extension_set_pin(new_password)?;
         Ok(())

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -270,7 +270,8 @@ where
             Command::ListCredentials => self.list_credentials(reply, None),
             Command::Register(register) => self.register(register),
             Command::Calculate(calculate) => self.calculate(calculate, reply),
-            // Command::CalculateAll(calculate_all) => self.calculate_all(calculate_all, reply),
+            #[cfg(feature = "calculate-all")]
+            Command::CalculateAll(calculate_all) => self.calculate_all(calculate_all, reply),
             Command::Delete(delete) => self.delete(delete),
             Command::Reset => self.reset(),
             #[cfg(feature = "challenge-response-auth")]
@@ -592,7 +593,7 @@ where
     //       06  <- digits
     //       5A D0 A7 CA <- dynamically truncated HMAC
     // 90 00
-    #[allow(dead_code)]
+    #[cfg(feature = "calculate-all")]
     fn calculate_all<const R: usize>(
         &mut self,
         calculate_all: command::CalculateAll<'_>,

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -203,7 +203,6 @@ where
             .state
             .with_persistent(&mut self.trussed, |_, state| !state.password_set());
 
-
         // TODO: abstract out this idea to make it usable for all the PIV security indicators
 
         let client_authorized_before = self.state.runtime.client_authorized;
@@ -253,11 +252,13 @@ where
                 #[cfg(feature = "challenge-response-auth")]
                 Command::Validate(_) => {}
                 Command::Reset => {}
+                // Always allow HOTP code verification
                 Command::VerifyCode(_) => {}
-                // Can't make session without a PIN
+                // Always allow to set PIN
                 Command::SetPin(_) => {}
+                // Always allow to verify PIN
                 Command::VerifyPin(_) => {}
-                // Protocol command for download the rest of the result
+                // Protocol command to download the rest of the result
                 Command::SendRemaining => {}
                 // No need to call verify on that, since it requires original PIN anyway
                 Command::ChangePin(_) => {}

--- a/src/command.rs
+++ b/src/command.rs
@@ -551,6 +551,7 @@ impl<'l, const C: usize> TryFrom<&'l iso7816::Command<C>> for Command<'l> {
                 (0x00, oath::Instruction::Calculate, 0x00, 0x01) => {
                     Self::Calculate(Calculate::try_from(data)?)
                 }
+                #[cfg(feature = "calculate-all")]
                 (0x00, oath::Instruction::CalculateAll, 0x00, 0x01) => {
                     Self::CalculateAll(CalculateAll::try_from(data)?)
                 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -562,6 +562,7 @@ impl<'l, const C: usize> TryFrom<&'l iso7816::Command<C>> for Command<'l> {
                     Self::Register(Register::try_from(data)?)
                 }
                 (0x00, oath::Instruction::Reset, 0xde, 0xad) => Self::Reset,
+                #[cfg(feature = "challenge-response-auth")]
                 (0x00, oath::Instruction::SetCode, 0x00, 0x00) => {
                     // should check this is a TLV(SetPassword, b'')
                     if data.len() == 2 {
@@ -570,6 +571,7 @@ impl<'l, const C: usize> TryFrom<&'l iso7816::Command<C>> for Command<'l> {
                         Self::SetPassword(SetPassword::try_from(data)?)
                     }
                 }
+                #[cfg(feature = "challenge-response-auth")]
                 (0x00, oath::Instruction::Validate, 0x00, 0x00) => {
                     Self::Validate(Validate::try_from(data)?)
                 }

--- a/src/ctaphid.rs
+++ b/src/ctaphid.rs
@@ -11,7 +11,8 @@ where
         + client::HmacSha1
         + client::HmacSha256
         + client::Sha256
-        + client::Chacha8Poly1305,
+        + client::Chacha8Poly1305
+        + trussed_auth::AuthClient,
 {
     fn commands(&self) -> &'static [HidCommand] {
         &[HidCommand::Vendor(OTP_CCID)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub const YUBICO_OATH_AID: &[u8] = &hex!("A000000527 2101"); // 01");
 pub const UP_TIMEOUT_MILLISECONDS: u32 = 15 * 1000;
 pub const FAILURE_FORCED_DELAY_MILLISECONDS: u32 = 1000;
 pub const BACKEND_USER_PIN_ID: u8 = 0;
+pub const ATTEMPT_COUNTER_DEFAULT_RETRIES: u8 = 8;
 
 // class AID(bytes, Enum):
 //     OTP = b'\xa0\x00\x00\x05\x27 \x20\x01'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub const YUBICO_OATH_AID: &[u8] = &hex!("A000000527 2101"); // 01");
 /// This constant defines timeout for the regular UP confirmation
 pub const UP_TIMEOUT_MILLISECONDS: u32 = 15 * 1000;
 pub const FAILURE_FORCED_DELAY_MILLISECONDS: u32 = 1000;
+pub const BACKEND_USER_PIN_ID: u8 = 0;
 
 // class AID(bytes, Enum):
 //     OTP = b'\xa0\x00\x00\x05\x27 \x20\x01'

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -21,6 +21,9 @@ pub enum Tag {
     InitialMovingFactor = 0x7a,
     Algorithm = 0x7b,
     Touch = 0x7c,
+    // Extension starting from 0x80
+    Password = 0x80,
+    NewPassword = 0x81,
 }
 
 #[repr(u8)]
@@ -88,6 +91,9 @@ pub enum Instruction {
     SendRemaining = 0xa5,
     // Place extending commands in 0xBx space
     VerifyCode = 0xb1,
+    VerifyPIN = 0xb2,
+    ChangePIN = 0xb3,
+    SetPIN = 0xb4,
 }
 
 impl TryFrom<u8> for Instruction {
@@ -105,6 +111,9 @@ impl TryFrom<u8> for Instruction {
             0xa4 => CalculateAll,
             0xa5 => SendRemaining,
             0xb1 => VerifyCode,
+            0xb2 => VerifyPIN,
+            0xb3 => ChangePIN,
+            0xb4 => SetPIN,
             _ => return Err(Self::Error::InstructionNotSupportedOrInvalid),
         })
     }

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -24,6 +24,7 @@ pub enum Tag {
     // Extension starting from 0x80
     Password = 0x80,
     NewPassword = 0x81,
+    PINCounter = 0x82,
 }
 
 #[repr(u8)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -53,6 +53,9 @@ pub struct Runtime {
     /// For book-keeping purposes, set client_authorized / prevents it from being cleared before
     /// returning control to caller of the app
     pub client_newly_authorized: bool,
+
+    /// Cache
+    pub encryption_key: Option<KeyId>,
 }
 
 impl Runtime {
@@ -110,8 +113,8 @@ impl State {
         O: Serialize,
     {
         let encryption_key = self
-            .get_encryption_key_from_state(trussed)
-            .map_err(|_| iso7816::Status::UnspecifiedPersistentExecutionError)?;
+            .get_encryption_key_from_state()
+            .map_err(|_| iso7816::Status::SecurityStatusNotSatisfied)?;
         let data = EncryptedDataContainer::from_obj(trussed, obj, None, encryption_key)
             .map_err(|_| Status::UnspecifiedPersistentExecutionError)?;
         let data_serialized: Message = data
@@ -127,22 +130,12 @@ impl State {
         Ok(())
     }
 
-    fn get_encryption_key_from_state<T>(&mut self, trussed: &mut T) -> trussed::error::Result<KeyId>
-    where
-        T: trussed::Client + trussed::client::Chacha8Poly1305,
-    {
-        // Try to read it
-        let maybe_encryption_key = self.with_persistent(trussed, |_, state| state.encryption_key);
-
-        // Generate encryption key
-        let location = self.location;
-        let encryption_key = match maybe_encryption_key {
-            Some(e) => e,
-            None => self.try_with_persistent_mut(trussed, |trussed, state| {
-                state.get_or_generate_encryption_key(trussed, location)
-            })?,
-        };
-        Ok(encryption_key)
+    fn get_encryption_key_from_state(&mut self) -> trussed::error::Result<KeyId> {
+        // Try to read cached field (should not be empty if unlocked)
+        if self.runtime.encryption_key.is_none() {
+            error_now!("No encryption key set in the cache");
+        }
+        self.runtime.encryption_key.ok_or(trussed::Error::NoSuchKey)
     }
 
     pub fn decrypt_content<T, O>(
@@ -155,7 +148,7 @@ impl State {
         O: DeserializeOwned,
     {
         let encryption_key = self
-            .get_encryption_key_from_state(trussed)
+            .get_encryption_key_from_state()
             .map_err(|_| encrypted_container::Error::FailedDecryption)?;
 
         EncryptedDataContainer::decrypt_from_bytes(trussed, ser_encrypted, encryption_key)

--- a/src/state.rs
+++ b/src/state.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use encrypted_container::EncryptedDataContainer;
 use trussed::types::Message;
 use trussed::{
-    cbor_deserialize, cbor_serialize_bytes, syscall, try_syscall,
+    cbor_deserialize, syscall, try_syscall,
     types::{KeyId, Location, PathBuf},
 };
 


### PR DESCRIPTION
Derive encryption key from the PIN, using the `trussed_auth` backend.

Uses:
-  https://github.com/trussed-dev/trussed/pull/102 for the nonce-less Chacha encryption;
-  https://github.com/trussed-dev/trussed-auth/pull/10 for the backend access.
- https://github.com/Nitrokey/pynitrokey/pull/329 WIP tests

Fixes #37 


Remarks:
1. The authorization mechanism is the same like with the original oath protocol and challenge-response method, that is each command accessing user data now requires call to VerifyPin - this unlocks the encryption key until the next command is executed, and removed from the volatile memory regardless of its result.
    - A better solution could be per session/power-cycle unlocking, like done with OpenPGP. To discuss.
2. It is no longer possible to use the application without auth token set, like it was for the challenge-response method.

To do / discuss:
- [ ] trussed-usbip is referenced by commit hash for the example build - move to tag
- [x] ~trussed~ and trussed-auth dependencies are unmerged PRs