### PR TITLE
Remove alloc crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ generate_macros!();
 
 #[macro_use(hex)]
 extern crate hex_literal;
-extern crate alloc;
 
 pub mod authenticator;
 


### PR DESCRIPTION
We don’t need alloc currently and should try to reduce its usage so that we can drop the allocator from the firmware once we have a non-allocating RSA implementation.