### PR TITLE
PIN-less credentials access with hardware key encryption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,4 @@ required-features = ["ctaphid", "devel"]
 flexiber = { git = "https://github.com/Nitrokey/flexiber", tag = "0.1.1.nitrokey" }
 trussed = { git = "https://github.com/Nitrokey/trussed", rev = "52da9bb" }
 littlefs2 = { git =  "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-2" }
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "v0.2.1" }
+trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth/", rev = "refs/pull/21/head" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ challenge-response-auth = []
 # Enable oath calculate-all command
 calculate-all = []
 
+# Require delay after failed request as a brute-force protection for Reverese HOTP Verification
+brute-force-delay = []
+
+
 log-all = []
 log-none = []
 log-info = []

--- a/components/encrypted_container/src/container.rs
+++ b/components/encrypted_container/src/container.rs
@@ -99,7 +99,7 @@ impl EncryptedDataContainer {
     /// Decrypt given Bytes and return original object instance
     pub fn decrypt_from_bytes<T, O>(
         trussed: &mut T,
-        ser_encrypted: Message,
+        ser_encrypted: &Message,
         encryption_key: KeyId,
     ) -> Result<O>
     where
@@ -107,7 +107,7 @@ impl EncryptedDataContainer {
         O: DeserializeOwned,
     {
         let deserialized_container: EncryptedDataContainer =
-            cbor_deserialize(&ser_encrypted).map_err(|_| Error::DeserializationToContainerError)?;
+            cbor_deserialize(ser_encrypted).map_err(|_| Error::DeserializationToContainerError)?;
 
         deserialized_container.decrypt(trussed, None, encryption_key)
     }

--- a/ctaphid.md
+++ b/ctaphid.md
@@ -220,6 +220,32 @@ Options:
 ```
 
 
+## Authentication Requirements
+
+
+| Command         | Require Touch Button press | Require PIN Authentication | Unlocks PIN-based Encryption Key |
+|-----------------|----------------------------|----------------------------|----------------------------------|
+| Select          | No                         | No                         | No                               |
+| Calculate       | Yes*                       | No                         | No                               |
+| CalculateAll    | No                         | No                         | No                               |
+| Delete          | Yes                        | Yes*                       | No                               |
+| ListCredentials | No                         | Yes*                       | No                               |
+| Register        | Yes                        | Yes*                       | No                               |
+| Reset           | Yes                        | No                         | No                               |
+| VerifyPin       | No                         | -                          | Yes                              |
+| SetPin          | Yes                        | -                          | No                               |
+| ChangePin       | Yes                        | -                          | No                               |
+| VerifyCode      | Yes*                       | No                         | No                               |
+| SendRemaining   | No                         | No                         | No                               |
+
+
+Notes: 
+1. \* If credential was encrypted using PIN-based key, then verification with PIN through `VerifyPin()` is required to get
+access to it, otherwise it will be reported as not found. Similarly, PIN-encrypted credentials will not be listed 
+with `List` command until authenticated. `Delete` command require PIN for Credentials created with PIN-encryption.
+2. Credentials can be configured to be allowed for use only after touch button is pressed.
+3. \* Touch Button press is required for Credentials, which were created with such attribute. 
+   
 ## Further development
 
 Current solution does have a couple of limitations, which could be corrected in the further development:

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -3,7 +3,7 @@ use core::time::Duration;
 
 use flexiber::{Encodable, EncodableHeapless};
 use heapless_bytes::Bytes;
-use iso7816::Status::SecurityStatusNotSatisfied;
+use iso7816::Status::{NotFound, SecurityStatusNotSatisfied};
 use iso7816::{Data, Status};
 use trussed::types::KeyId;
 use trussed::types::Location;
@@ -394,6 +394,8 @@ where
                 &self.filename_for_label(label),
                 _deletion_result
             );
+        } else {
+            return Err(NotFound);
         }
         Ok(())
     }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -915,8 +915,10 @@ where
         const COUNTER_WINDOW_SIZE: u32 = 9;
 
         #[cfg(feature = "brute-force-delay")]
-        self.deny_if_too_soon_after_failure()?;
-        self.mark_failed_verification_time()?;
+        {
+            self.deny_if_too_soon_after_failure()?;
+            self.mark_failed_verification_time()?;
+        }
 
         let credential = self.load_credential(args.label).ok_or(Status::NotFound)?;
 
@@ -963,6 +965,7 @@ where
         };
 
         self.bump_counter_for_cred(&credential, found)?;
+        #[cfg(feature = "brute-force-delay")]
         self.clear_failed_verification_time();
         self.wink_good();
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -256,8 +256,15 @@ where
         let command: Command = command.try_into()?;
         info_now!("{:?}", &command);
 
-        // Allow all commands to be called without PIN verification
+        // Make sure the "remaining" state is cleared if the new command is sent
+        // It will clear itself with the final packet sent
+        if !matches!(command, Command::SendRemaining){
+            self.state.runtime.previously = None;
+        }
 
+        // DESIGN Allow all commands to be called without PIN verification
+
+        // Lazy init: make sure hardware key is initialized
         self.init()?;
 
         // Process the request
@@ -291,7 +298,7 @@ where
         if self.state.runtime.encryption_key.is_some() {
             // Do not call automatic logout after these commands
             match command {
-                // Always allow to verify PIN
+                // Always leave PIN KEK after verify PIN
                 Command::VerifyPin(_) => {}
                 _ => {
                     if self.state.runtime.previously.is_none() {

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -71,7 +71,7 @@ impl Default for OathVersion {
         // OathVersion { major: 1, minor: 0, patch: 0}
         OathVersion {
             major: 4,
-            minor: 7,
+            minor: 10,
             patch: 0,
         }
     }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -1122,8 +1122,8 @@ where
         Ok(())
     }
 
-    fn _debug_trussed_backend_error(e: trussed::Error, l: u32) -> iso7816::Status {
-        info_now!("Trussed backend error: {:?} (line {:?})", e, l);
+    fn _debug_trussed_backend_error(_e: trussed::Error, _l: u32) -> iso7816::Status {
+        info_now!("Trussed backend error: {:?} (line {:?})", _e, _l);
         iso7816::Status::UnspecifiedNonpersistentExecutionError
     }
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -348,11 +348,9 @@ where
             self.state.try_read_file(&mut self.trussed, filename).ok()?;
         // Set the default EncryptionKeyType as PinBased for backwards compatibility
         // All the new records should have it set as HardwareBased, if not overridden by user
-        credential.encryption_key_type = Some(
-            credential
-                .encryption_key_type
-                .unwrap_or(EncryptionKeyType::default_for_loading_credential()),
-        );
+        if credential.encryption_key_type.is_none() {
+            credential.encryption_key_type = Some(EncryptionKeyType::default_for_loading_credential());
+        }
 
         if label != credential.label.as_slice() {
             error_now!("Loaded credential label is different than expected. Aborting.");

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -291,15 +291,13 @@ where
         if self.state.runtime.encryption_key.is_some() {
             // Do not call automatic logout after these commands
             match command {
-                // Always allow to set PIN
-                Command::SetPin(_) => {}
                 // Always allow to verify PIN
                 Command::VerifyPin(_) => {}
-                // Protocol command to download the rest of the result
-                Command::SendRemaining => {}
                 _ => {
-                    debug_now!("Calling logout");
-                    self._extension_logout().ok();
+                    if self.state.runtime.previously.is_none() {
+                        debug_now!("Calling logout");
+                        self._extension_logout().ok();
+                    }
                 }
             }
         };

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -9,7 +9,7 @@ use trussed::types::KeyId;
 use trussed::types::Location;
 use trussed::{client, syscall, try_syscall, types::PathBuf};
 
-use crate::command::VerifyCode;
+use crate::command::{EncryptionKeyType, VerifyCode};
 use crate::credential::Credential;
 use crate::oath::Kind;
 use crate::{
@@ -196,6 +196,12 @@ where
         }
     }
 
+    pub fn init(&mut self) {
+        if self.state.runtime.encryption_key_hardware.is_none() {
+            self.state.runtime.encryption_key_hardware = self._extension_get_hardware_key().ok();
+        }
+    }
+
     pub fn respond<const C: usize, const R: usize>(
         &mut self,
         command: &iso7816::Command<C>,
@@ -245,30 +251,16 @@ where
         )?;
         ensure(class.channel() == Some(0), Status::ClassNotSupported)?;
 
-        // parse Iso7816Command as PivCommand
+        // parse Iso7816Command
         let command: Command = command.try_into()?;
         info_now!("{:?}", &command);
 
-        if !self.state.runtime.client_authorized {
-            match command {
-                Command::Select(_) => {}
-                #[cfg(feature = "challenge-response-auth")]
-                Command::Validate(_) => {}
-                Command::Reset => {}
-                // Always allow HOTP code verification
-                Command::VerifyCode(_) => {}
-                // Always allow to set PIN
-                Command::SetPin(_) => {}
-                // Always allow to verify PIN
-                Command::VerifyPin(_) => {}
-                // Protocol command to download the rest of the result
-                Command::SendRemaining => {}
-                // No need to call verify on that, since it requires original PIN anyway
-                Command::ChangePin(_) => {}
-                _ => return Err(Status::ConditionsOfUseNotSatisfied),
-            }
-        }
-        match command {
+        // Allow all commands to be called without PIN verification
+
+        self.init();
+
+        // Process the request
+        let result = match command {
             Command::Select(select) => self.select(select, reply),
             Command::ListCredentials => self.list_credentials(reply, None),
             Command::Register(register) => self.register(register),
@@ -291,7 +283,27 @@ where
 
             Command::SendRemaining => self.send_remaining(reply),
             _ => Err(Status::ConditionsOfUseNotSatisfied),
-        }
+        };
+
+        // Call logout after processing, so the PIN-based KEK would not be kept in the memory
+        // DESIGN -> Per-request authorization
+        if self.state.runtime.encryption_key.is_some() {
+            // Do not call automatic logout after these commands
+            match command {
+                // Always allow to set PIN
+                Command::SetPin(_) => {}
+                // Always allow to verify PIN
+                Command::VerifyPin(_) => {}
+                // Protocol command to download the rest of the result
+                Command::SendRemaining => {}
+                _ => {
+                    debug_now!("Calling logout");
+                    self._extension_logout().ok();
+                }
+            }
+        };
+
+        result
     }
 
     fn select<const R: usize>(
@@ -326,7 +338,11 @@ where
     fn load_credential(&mut self, label: &[u8]) -> Option<Credential> {
         let filename = self.filename_for_label(label);
 
-        let credential: Credential = self.state.try_read_file(&mut self.trussed, filename).ok()?;
+        let mut credential: Credential =
+            self.state.try_read_file(&mut self.trussed, filename).ok()?;
+        // Set the default EncryptionKeyType as PinBased for backwards compatibility
+        // All new records should have it set as HardwareBased, if not overridden by user
+        credential.key_type = Some(credential.key_type.unwrap_or(EncryptionKeyType::PinBased));
 
         if label != credential.label.as_slice() {
             error_now!("Loaded credential label is different than expected. Aborting.");
@@ -356,9 +372,6 @@ where
     }
 
     fn delete(&mut self, delete: command::Delete<'_>) -> Result {
-        if !self.state.runtime.client_authorized {
-            return Err(Status::ConditionsOfUseNotSatisfied);
-        }
         debug_now!("{:?}", delete);
         // It seems tooling first lists all credentials, so the case of
         // delete being called on a non-existing label hardly occurs.
@@ -406,9 +419,6 @@ where
         reply: &mut Data<R>,
         file_index: Option<usize>,
     ) -> Result {
-        if !self.state.runtime.client_authorized && self.state.runtime.previously.is_none() {
-            return Err(Status::ConditionsOfUseNotSatisfied);
-        }
         // info_now!("recv ListCredentials");
         // return Ok(Default::default());
         // 72 13 21
@@ -452,16 +462,18 @@ where
         };
 
         let mut file_index = file_index;
-        while let Some(credential) = maybe_credential {
-            // Try to serialize, abort if not succeeded
-            let current_reply_bytes_count = reply.len();
-            let res = Self::try_to_serialize_credential_for_list(&credential, reply);
-            if res.is_err() {
-                // Revert reply vector to the last good size, removing debris from the failed
-                // serialization
-                reply.truncate(current_reply_bytes_count);
-                return Err(Status::MoreAvailable(0xFF));
-            }
+        loop {
+            if let Some(credential) = maybe_credential {
+                // Try to serialize, abort if does not fit into the reply buffer
+                let current_reply_bytes_count = reply.len();
+                let res = Self::try_to_serialize_credential_for_list(&credential, reply);
+                if res.is_err() {
+                    // Revert reply vector to the last good size, removing debris from the failed
+                    // serialization
+                    reply.truncate(current_reply_bytes_count);
+                    return Err(Status::MoreAvailable(0xFF));
+                }
+            };
 
             // keep track, in case we need continuation
             file_index += 1;
@@ -469,7 +481,9 @@ where
 
             // check if there's more
             maybe_credential = match syscall!(self.trussed.read_dir_files_next()).data {
-                None => None,
+                // no more files, break the loop and return
+                None => break,
+                // we do not have the right key, continue
                 Some(c) => self.state.decrypt_content(&mut self.trussed, c).ok(),
             };
         }
@@ -500,11 +514,9 @@ where
     fn register(&mut self, register: command::Register<'_>) -> Result {
         self.user_present()?;
 
-        if !self.state.runtime.client_authorized {
-            return Err(Status::ConditionsOfUseNotSatisfied);
-        }
         // info_now!("recv {:?}", &register);
 
+        // Allow to overwrite existing credentials by default
         // 0. ykman does not call delete before register, so we need to speculatively
         // delete the credential (the credential file would be replaced, but we need
         // to delete the secret key).
@@ -521,9 +533,12 @@ where
         let filename = self.filename_for_label(&credential.label);
 
         // 3. Serialize the credential (implicitly) and store it
-        let write_res = self
-            .state
-            .try_write_file(&mut self.trussed, filename, &credential);
+        let write_res = self.state.try_write_file(
+            &mut self.trussed,
+            filename,
+            &credential,
+            credential.key_type,
+        );
 
         if write_res.is_err() {
             // 1. Try to delete the empty file, ignore errors
@@ -629,9 +644,6 @@ where
         calculate: command::Calculate<'_>,
         reply: &mut Data<R>,
     ) -> Result {
-        if !self.state.runtime.client_authorized {
-            return Err(Status::ConditionsOfUseNotSatisfied);
-        }
         // info_now!("recv {:?}", &calculate);
 
         let credential = self
@@ -776,9 +788,6 @@ where
     fn set_password(&mut self, set_password: command::SetPassword<'_>) -> Result {
         self.user_present()?;
 
-        if !self.state.runtime.client_authorized {
-            return Err(Status::ConditionsOfUseNotSatisfied);
-        }
         // when there is no password set:
         // APDU: 00 A4 04 00 07 (SELECT)
         //                      A0 00 00 05 27 21 01
@@ -902,6 +911,8 @@ where
     /// Device will stop verifying the HOTP codes in case, when the difference between the host and on-device counters will be greater or equal to 10.
     fn verify_code<const R: usize>(&mut self, args: VerifyCode, reply: &mut Data<{ R }>) -> Result {
         const COUNTER_WINDOW_SIZE: u32 = 9;
+
+        #[cfg(feature = "brute-force-delay")]
         self.deny_if_too_soon_after_failure()?;
         self.mark_failed_verification_time()?;
 
@@ -1001,8 +1012,12 @@ where
         );
         // save credential back, with the updated counter
         let filename = self.filename_for_label(&credential.label);
-        self.state
-            .try_write_file(&mut self.trussed, filename, &credential)?;
+        self.state.try_write_file(
+            &mut self.trussed,
+            filename,
+            &credential,
+            credential.key_type,
+        )?;
 
         Ok(credential)
     }
@@ -1032,6 +1047,11 @@ where
     fn _extension_pin_factory_reset(&mut self) -> Result {
         self._extension_logout()?;
 
+        if let Some(key) = self.state.runtime.encryption_key_hardware.take() {
+            try_syscall!(self.trussed.delete(key))
+                .map_err(|e| Self::_debug_trussed_backend_error(e, line!()))?;
+        }
+
         try_syscall!(self.trussed.delete_all_pins())
             .map_err(|e| Self::_debug_trussed_backend_error(e, line!()))?;
 
@@ -1049,6 +1069,24 @@ where
         } else {
             Ok(())
         }
+    }
+
+    fn _extension_get_hardware_key(&mut self) -> Result<KeyId> {
+        let password: &[u8] = "HARDWARE KEY".as_ref();
+        let pin_id = BACKEND_USER_PIN_ID + 1;
+        try_syscall!(self.trussed.set_pin(
+            pin_id,
+            Bytes::from_slice(password).unwrap(),
+            None,
+            true
+        ))
+        .ok();
+        let reply = try_syscall!(self.trussed.get_pin_key(
+            pin_id,
+            Bytes::from_slice(password).map_err(|_| iso7816::Status::IncorrectDataParameter)?
+        ))
+        .map_err(|e| Self::_debug_trussed_backend_error(e, line!()))?;
+        reply.result.ok_or(iso7816::Status::VerificationFailed)
     }
 
     fn _extension_set_pin(&mut self, password: &[u8]) -> Result {
@@ -1154,7 +1192,6 @@ where
 
         self._extension_change_pin(password, new_password)
             .map_err(|_| Status::VerificationFailed)?;
-        self.state.runtime.client_newly_authorized = true;
         Ok(())
     }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -459,13 +459,6 @@ impl EncryptionKeyType {
     }
 }
 
-impl Default for EncryptionKeyType {
-    fn default() -> Self {
-        // For backwards compatibility, the default
-        Self::default_for_loading_credential()
-    }
-}
-
 impl<'l, const C: usize> TryFrom<&'l Data<C>> for Register<'l> {
     type Error = iso7816::Status;
     fn try_from(data: &'l Data<C>) -> Result<Self, Self::Error> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -450,6 +450,22 @@ pub enum EncryptionKeyType {
     PinBased,
 }
 
+impl EncryptionKeyType {
+    pub fn default_for_loading_credential() -> EncryptionKeyType {
+        EncryptionKeyType::PinBased
+    }
+    pub fn default_for_command_registering_new_credential() -> EncryptionKeyType {
+        EncryptionKeyType::Hardware
+    }
+}
+
+impl Default for EncryptionKeyType {
+    fn default() -> Self {
+        // For backwards compatibility, the default
+        Self::default_for_loading_credential()
+    }
+}
+
 impl<'l, const C: usize> TryFrom<&'l Data<C>> for Register<'l> {
     type Error = iso7816::Status;
     fn try_from(data: &'l Data<C>) -> Result<Self, Self::Error> {

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -1,3 +1,4 @@
+use crate::command::EncryptionKeyType;
 use crate::{command, oath};
 use serde::{Deserialize, Serialize};
 use trussed::types::ShortData;
@@ -29,6 +30,10 @@ pub struct Credential {
     pub touch_required: bool,
     #[serde(rename = "C")]
     pub counter: Option<u32>,
+
+    #[serde(rename = "E")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_type: Option<EncryptionKeyType>,
 }
 
 impl Credential {
@@ -41,6 +46,7 @@ impl Credential {
             secret: ShortData::from_slice(credential.secret)?,
             touch_required: credential.touch_required,
             counter: credential.counter,
+            key_type: Some(credential.encryption_key_type),
         })
     }
 }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -33,7 +33,8 @@ pub struct Credential {
 
     #[serde(rename = "E")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub key_type: Option<EncryptionKeyType>,
+    // #[serde(default = "EncryptionKeyType::default_for_loading_credential")]
+    pub encryption_key_type: Option<EncryptionKeyType>,
 }
 
 impl Credential {
@@ -46,7 +47,7 @@ impl Credential {
             secret: ShortData::from_slice(credential.secret)?,
             touch_required: credential.touch_required,
             counter: credential.counter,
-            key_type: Some(credential.encryption_key_type),
+            encryption_key_type: Some(credential.encryption_key_type),
         })
     }
 }

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -76,6 +76,7 @@ pub fn combine(kind: Kind, algorithm: Algorithm) -> u8 {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Properties {
     RequireTouch = 0x02,
+    PINEncrypt = 0x04,
 }
 
 #[repr(u8)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -130,7 +130,7 @@ impl State {
             EncryptionKeyType::PinBased => self.runtime.encryption_key,
         };
         if key.is_none() {
-            error_now!(
+            warn_now!(
                 "No encryption key set in the cache for type {:?}",
                 encryption_key_type
             );


### PR DESCRIPTION
This PR adds PIN-less credentials access by using hardware key encryption by default, instead of requiring user's PIN.

Change list:
- The Credentials can be now optionally encrypted with the PIN-based key. 
- Data buffer for Send Remaining is now cleared on another command call.
- All PIN use is now protected with a touch button.
- Brute-force protection for HOTP Verification is feature gated and disabled by default for this release.
- Updated documentation.
- Use unmerged trussed-auth PR as a dependency: https://github.com/trussed-dev/trussed-auth/issues/20.
- Return error on an attempt to delete a non-existing Credential (was silently failing before).
- Credential struct has changed, however it's backward compatible with the previous one, and does not need a migration.

Tests were updated and all are passing:
- https://github.com/Nitrokey/pynitrokey/pull/377

To do:
- [x] cleanup

Potential problems found:
- PIN-protected Credential can't be removed without PIN, but can be overwritten by registering new one with the same name;
- PIN length is not checked, so a single character PIN setting is possible;
- trussed-auth dependency should be set to an official tagged release;
- currently there is no possibility to reset the PIN without clearing all user data, including these not depending on the PIN.

Fixes #48 

