### PR TITLE
Use cbor_smol instead of trussed re-exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "OATH authenticator Trussed app"
 [dependencies]
 apdu-dispatch = { version = "0.1.2",  optional = true }
 ctaphid-dispatch = { version = "0.1", optional = true }
+cbor-smol = "0.4"
 delog = "0.1.6"
 flexiber = { version = "0.1.0", features = ["derive", "heapless"] }
 heapless = "0.7"

--- a/components/encrypted_container/Cargo.toml
+++ b/components/encrypted_container/Cargo.toml
@@ -15,6 +15,7 @@ trussed = { version = "0.1" }
 heapless = "0.7"
 heapless-bytes = "0.3"
 serde = { version = "1", default-features = false }
+cbor-smol = "0.4"
 delog = "0.1.6"
 
 [features]

--- a/components/encrypted_container/src/container.rs
+++ b/components/encrypted_container/src/container.rs
@@ -1,8 +1,11 @@
+use cbor_smol::{cbor_deserialize, cbor_serialize};
 use heapless_bytes::Bytes;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
-use trussed::types::{KeyId, Message};
-use trussed::{cbor_deserialize, cbor_serialize, try_syscall};
+use trussed::{
+    try_syscall,
+    types::{KeyId, Message},
+};
 
 /// Universal AEAD encrypted data container, using CBOR and Chacha8Poly1305
 ///

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,11 +5,12 @@ use iso7816::Status;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use cbor_smol::cbor_deserialize;
 use crate::command::EncryptionKeyType;
 use encrypted_container::EncryptedDataContainer;
 use trussed::types::Message;
 use trussed::{
-    cbor_deserialize, syscall, try_syscall,
+    syscall, try_syscall,
     types::{KeyId, Location, PathBuf},
 };
 


### PR DESCRIPTION
This patch replaces the re-exports of cbor_serialize and cbor_deserialize from trussed with using cbor_smol directly.  This makes this crate compatible with the latest upstream Trussed.