### PR TITLE
Extend Credential structure with Password Safe field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oath-authenticator"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Nicolas Stalder <n@stalder.io>", "Szczepan Zalega <szczepan@nitrokey.com>"]
 repository = "https://github.com/trussed-dev/oath-authenticator"
 edition = "2021"

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -749,7 +749,7 @@ where
                 return Err(Status::SecurityStatusNotSatisfied);
             }
             _ => {
-                return Err(Status::UnspecifiedPersistentExecutionError);
+                return Err(Status::ConditionsOfUseNotSatisfied);
             }
         };
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -5,7 +5,7 @@ use core::time::Duration;
 
 use flexiber::{Encodable, EncodableHeapless};
 use heapless_bytes::Bytes;
-use iso7816::Status::NotFound;
+use iso7816::Status::{NotFound, UnspecifiedNonpersistentExecutionError};
 use iso7816::{Data, Status};
 use trussed::types::Location;
 use trussed::types::{KeyId, Message};
@@ -277,6 +277,7 @@ where
             Command::ListCredentials => self.list_credentials(reply, None),
             Command::Register(register) => self.register(register),
             Command::Calculate(calculate) => self.calculate(calculate, reply),
+            Command::GetCredential(get) => self.get_credential(get, reply),
             #[cfg(feature = "calculate-all")]
             Command::CalculateAll(calculate_all) => self.calculate_all(calculate_all, reply),
             Command::Delete(delete) => self.delete(delete),
@@ -660,6 +661,55 @@ where
         Ok(())
     }
 
+    fn try_to_serialize_credential_for_get_credential<const R: usize>(
+        credential: Credential,
+        reply: &mut Data<R>,
+    ) -> core::result::Result<(), u8> {
+        reply.push(oath::Tag::Property as u8)?;
+        reply.push(1)?;
+        reply.push(oath::combine(credential.kind, credential.algorithm))?;
+
+        for (tag, field) in &[
+            (oath::Tag::Name, Some(credential.label)),
+            (oath::Tag::PwsLogin, credential.login),
+            (oath::Tag::PwsPassword, credential.password),
+            (oath::Tag::PwsMetadata, credential.metadata),
+        ] {
+            if let Some(value) = field {
+                reply.push(*tag as u8)?;
+                reply.push((value.len()) as u8)?;
+                reply.extend_from_slice(&value).map_err(|_| 0)?;
+            }
+            if reply.len() > CTAPHID_MESSAGE_SIZE_LIMIT {
+                // Finish early due to the usbd-ctaphid message size limit
+                return Err(1);
+            }
+        }
+        Ok(())
+    }
+
+    fn get_credential<const R: usize>(
+        &mut self,
+        get_credential_req: command::GetCredential<'_>,
+        reply: &mut Data<R>,
+    ) -> Result {
+        let credential = self
+            .load_credential(get_credential_req.label)
+            .ok_or(Status::NotFound)?;
+
+        // DESIGN Daily use: require touch button if set on the credential, but not if the PIN was already checked
+        // Safety: encryption_key_type should be set for credential during loading in load_credential
+        if credential.touch_required
+            && credential.encryption_key_type.unwrap() != EncryptionKeyType::PinBased
+        {
+            self.user_present()?;
+        }
+
+        Self::try_to_serialize_credential_for_get_credential(credential, reply)
+            .map_err(|_| UnspecifiedNonpersistentExecutionError)?;
+        Ok(())
+    }
+
     fn calculate<const R: usize>(
         &mut self,
         calculate: command::Calculate<'_>,
@@ -697,6 +747,9 @@ where
             Kind::HotpReverse => {
                 // This credential kind should never be access through calculate()
                 return Err(Status::SecurityStatusNotSatisfied);
+            }
+            _ => {
+                return Err(Status::UnspecifiedPersistentExecutionError);
             }
         };
 

--- a/src/ctaphid.rs
+++ b/src/ctaphid.rs
@@ -1,4 +1,4 @@
-use crate::Authenticator;
+use crate::{Authenticator, CTAPHID_MESSAGE_SIZE_LIMIT};
 use ctaphid_dispatch::app::{self, Command as HidCommand, Message};
 use ctaphid_dispatch::command::VendorCommand;
 use iso7816::Status;
@@ -24,7 +24,7 @@ where
         input_data: &Message,
         response: &mut Message,
     ) -> app::AppResult {
-        const MAX_COMMAND_LENGTH: usize = 255;
+        const MAX_COMMAND_LENGTH: usize = CTAPHID_MESSAGE_SIZE_LIMIT;
         match command {
             HidCommand::Vendor(OTP_CCID) => {
                 let arr: [u8; 2] = Status::Success.into();

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -25,6 +25,40 @@ pub enum Tag {
     Password = 0x80,
     NewPassword = 0x81,
     PINCounter = 0x82,
+
+    PwsLogin = 0x83,
+    PwsPassword = 0x84,
+    PwsMetadata = 0x85,
+    // Remember to update try_from below when adding new tags
+}
+
+impl TryFrom<u8> for Tag {
+    type Error = iso7816::Status;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0x71 => Tag::Name,
+            0x72 => Tag::NameList,
+            0x73 => Tag::Key,
+            0x74 => Tag::Challenge,
+            0x75 => Tag::Response,
+
+            0x77 => Tag::Hotp,
+            0x78 => Tag::Property,
+            0x79 => Tag::Version,
+            0x7a => Tag::InitialMovingFactor,
+            0x7b => Tag::Algorithm,
+            0x7c => Tag::Touch,
+
+            0x81 => Tag::NewPassword,
+            0x82 => Tag::PINCounter,
+
+            0x83 => Tag::PwsLogin,
+            0x84 => Tag::PwsPassword,
+            0x85 => Tag::PwsMetadata,
+            _ => return Err(Self::Error::IncorrectDataParameter),
+        })
+    }
 }
 
 #[repr(u8)]
@@ -54,6 +88,7 @@ pub enum Kind {
     Hotp = 0x10,
     Totp = 0x20,
     HotpReverse = 0x30,
+    NotSet = 0x40,
 }
 
 impl TryFrom<u8> for Kind {
@@ -63,6 +98,7 @@ impl TryFrom<u8> for Kind {
             0x10 => Kind::Hotp,
             0x20 => Kind::Totp,
             0x30 => Kind::HotpReverse,
+            0x40 => Kind::NotSet,
             _ => return Err(Self::Error::IncorrectDataParameter),
         })
     }
@@ -96,6 +132,7 @@ pub enum Instruction {
     VerifyPIN = 0xb2,
     ChangePIN = 0xb3,
     SetPIN = 0xb4,
+    GetCredential = 0xb5,
 }
 
 impl TryFrom<u8> for Instruction {
@@ -116,6 +153,7 @@ impl TryFrom<u8> for Instruction {
             0xb2 => VerifyPIN,
             0xb3 => ChangePIN,
             0xb4 => SetPIN,
+            0xb5 => GetCredential,
             _ => return Err(Self::Error::InstructionNotSupportedOrInvalid),
         })
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -5,8 +5,8 @@ use iso7816::Status;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
-use cbor_smol::cbor_deserialize;
 use crate::command::EncryptionKeyType;
+use cbor_smol::cbor_deserialize;
 use encrypted_container::EncryptedDataContainer;
 use trussed::types::Message;
 use trussed::{


### PR DESCRIPTION
Extend Credential structure with Password Safe field

Add GetCredential command
Allow additional fields in Register command
New tags for the PWS fields
New OTP kind to signalize OTP being unused in the given Credential, without changing the data structure

Remarks:
- This change is backwards-compatible with the previous user data, and do not need data migration.
- Data created with firmware using this application may block working of the older version (e.g. if user moved to `test` firmware, and want to get back to stable firmware). Reset procedure should be able to recover all features though.


Fixes https://github.com/Nitrokey/trussed-secrets-app/issues/60