### PR TITLE
Add challenge-response method for KeepassXC support

### DIFF
--- a/examples/usbip.rs
+++ b/examples/usbip.rs
@@ -299,6 +299,7 @@ impl trussed_usbip::Apps<VirtClient, dispatch::Dispatch> for Apps {
             Location::Internal,
             CustomStatus::ReverseHotpSuccess as u8,
             CustomStatus::ReverseHotpError as u8,
+            [0x42, 0x42, 0x42, 0x42],
         );
         let otp = oath_authenticator::Authenticator::new(
             builder.build("otp", dispatch::BACKENDS),


### PR DESCRIPTION
Add support for KeepassXC through challenge-response method.

Tests: https://github.com/Nitrokey/pynitrokey/pull/384
KeepassXC integration: https://github.com/keepassxreboot/keepassxc/pull/9397
~Does not contain PWS: https://github.com/Nitrokey/trussed-secrets-app/pull/63~ With PWS now.

Incompatible changes:
- runner should provide now via options the device's serial number


To discuss:
- [ ] Should returned version in the Status command be application or runner firmware version (to show up in KeepassXC, see linked PR)
- [x] Regarding used PKCS#7 unpadding, extract to separate crate or use known good implementation
- [ ] Would unchecked get bring any performance improvement (in unpadding)

To do in the next PRs:
- [x] Encode input verification logic into separate types; ( see https://github.com/Nitrokey/trussed-secrets-app/pull/63#issuecomment-1536058181 as well)
- [ ] Set version up automatically during the build from the project version

To test later:
- [ ] Use touch protected HMAC secret slot

Fixes #61 