### PR TITLE
Reorganize runtime Credential structure for clearer implementation

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -14,9 +14,10 @@ use trussed::types::{KeyId, Message};
 use trussed::{client, syscall, try_syscall, types::PathBuf};
 
 use crate::calculate::hmac_challenge;
-use crate::command::{EncryptionKeyType, VerifyCode, YKGetHMAC};
-use crate::credential::Credential;
-use crate::oath::{Algorithm, Kind};
+use crate::command::CredentialData::HmacData;
+use crate::command::{Credential, EncryptionKeyType, VerifyCode, YKGetHMAC};
+use crate::credential::CredentialFlat;
+use crate::oath::Algorithm;
 use crate::{
     command, ensure, oath,
     state::{CommandState, State},
@@ -378,10 +379,10 @@ where
         Ok(())
     }
 
-    fn load_credential(&mut self, label: &[u8]) -> Option<Credential> {
+    fn load_credential(&mut self, label: &[u8]) -> Option<CredentialFlat> {
         let filename = self.filename_for_label(label);
 
-        let mut credential: Credential =
+        let mut credential: CredentialFlat =
             self.state.try_read_file(&mut self.trussed, filename).ok()?;
         // Set the default EncryptionKeyType as PinBased for backwards compatibility
         // All the new records should have it set as HardwareBased, if not overridden by user
@@ -448,7 +449,7 @@ where
     }
 
     fn try_to_serialize_credential_for_list<const R: usize>(
-        credential: &Credential,
+        credential: &CredentialFlat,
         reply: &mut Data<R>,
     ) -> core::result::Result<(), u8> {
         reply.push(0x72)?;
@@ -503,7 +504,7 @@ where
                 }
             };
 
-            let maybe_credential: Option<Credential> = match file {
+            let maybe_credential: Option<CredentialFlat> = match file {
                 None => None,
                 Some(c) => self.state.decrypt_content(&mut self.trussed, c).ok(),
             };
@@ -581,7 +582,7 @@ where
 
         // 1. Replace secret in credential with handle
         let credential =
-            Credential::try_from(&register.credential).map_err(|_| Status::NotEnoughMemory)?;
+            CredentialFlat::try_from(&register.credential).map_err(|_| Status::NotEnoughMemory)?;
 
         // 2. Generate a filename for the credential
         let filename = self.filename_for_label(&credential.label);
@@ -654,7 +655,7 @@ where
             None
         ))
         .data;
-        let mut maybe_credential: Option<Credential> = match maybe_credential_enc {
+        let mut maybe_credential: Option<CredentialFlat> = match maybe_credential_enc {
             None => None,
             Some(c) => self.state.decrypt_content(&mut self.trussed, c).ok(),
         };
@@ -694,7 +695,7 @@ where
     }
 
     fn try_to_serialize_credential_for_get_credential<const R: usize>(
-        credential: Credential,
+        credential: CredentialFlat,
         reply: &mut Data<R>,
     ) -> core::result::Result<(), u8> {
         reply.push(oath::Tag::Property as u8)?;
@@ -736,7 +737,7 @@ where
         Ok(())
     }
 
-    fn require_touch_if_needed(&mut self, credential: &Credential) -> Result<()> {
+    fn require_touch_if_needed(&mut self, credential: &CredentialFlat) -> Result<()> {
         // DESIGN Daily use: require touch button if set on the credential, but not if the PIN was already checked
         // Safety: encryption_key_type should be set for credential during loading in load_credential
         if credential.touch_required
@@ -1080,7 +1081,7 @@ where
 
     fn calculate_hotp_code_for_counter(
         &mut self,
-        credential: &Credential,
+        credential: &CredentialFlat,
         counter: u32,
     ) -> iso7816::Result<u32> {
         let truncated_digest = self.calculate_hotp_digest_for_counter(credential, counter)?;
@@ -1095,7 +1096,7 @@ where
 
     fn calculate_hotp_digest_and_bump_counter(
         &mut self,
-        credential: &Credential,
+        credential: &CredentialFlat,
         counter: u32,
     ) -> iso7816::Result<[u8; 4]> {
         let credential = self.bump_counter_for_cred(credential, counter)?;
@@ -1105,9 +1106,9 @@ where
 
     fn bump_counter_for_cred(
         &mut self,
-        credential: &Credential,
+        credential: &CredentialFlat,
         counter: u32,
-    ) -> Result<Credential> {
+    ) -> Result<CredentialFlat> {
         // Do abort with error on the max value, so these could not be pregenerated,
         // and returned to user after overflow, or the same code used each time
         // load-bump counter
@@ -1131,7 +1132,7 @@ where
 
     fn calculate_hotp_digest_for_counter(
         &mut self,
-        credential: &Credential,
+        credential: &CredentialFlat,
         counter: u32,
     ) -> Result<[u8; 4]> {
         let counter_long: u64 = counter.into();
@@ -1360,31 +1361,25 @@ where
 
     fn yk_hmac<const R: usize>(&mut self, req: YKGetHMAC, reply: &mut Data<{ R }>) -> Result {
         // Get HMAC slot command
-
         let credential = self
             .load_credential(req.get_credential_label()?)
             .ok_or(Status::NotFound)?;
-        let key: &[u8] = &credential.secret;
-
-        // Make sure the set Credential is the right kind
-        ensure(
-            credential.kind == Kind::Hmac,
-            Status::IncorrectDataParameter,
-        )?;
-
-        let signature = hmac_challenge(&mut self.trussed, Algorithm::Sha1, req.challenge, key)?;
-
-        // TODO remove this check?
-        const HMAC_SHA1_LENGTH: usize = 20;
-        ensure(
-            signature.len() == HMAC_SHA1_LENGTH,
-            UnspecifiedNonpersistentExecutionError,
-        )?;
-
-        reply
-            .extend_from_slice(signature.as_slice())
-            .map_err(|_| UnspecifiedNonpersistentExecutionError)?;
-        Ok(())
+        let credential: Credential = credential.try_unpack_into_credential()?;
+        if let Some(otpdata) = credential.otp {
+            if let HmacData(x) = otpdata {
+                let key: &[u8] = x.secret;
+                let signature =
+                    hmac_challenge(&mut self.trussed, Algorithm::Sha1, req.challenge, key)?;
+                reply
+                    .extend_from_slice(signature.as_slice())
+                    .map_err(|_| UnspecifiedNonpersistentExecutionError)?;
+                Ok(())
+            } else {
+                return Err(Status::IncorrectDataParameter);
+            }
+        } else {
+            return Err(Status::IncorrectDataParameter);
+        }
     }
 
     fn yk_status<const R: usize>(&self, reply: &mut Data<{ R }>) -> Result {

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -137,7 +137,6 @@ impl flexiber::Encodable for SerialType {
     }
 }
 
-
 #[derive(Clone, Copy, Encodable, Eq, PartialEq)]
 struct PINAnswerToSelect {
     #[tlv(simple = "0x79")] // Tag::Version
@@ -363,7 +362,8 @@ where
         let state = self
             .state
             .with_persistent(&mut self.trussed, |_, state| state.clone());
-        let answer_to_select = AnswerToSelect::new(state.salt, SerialType(self.options.serial_number));
+        let answer_to_select =
+            AnswerToSelect::new(state.salt, SerialType(self.options.serial_number));
 
         let data: heapless::Vec<u8, 128> = if self._extension_is_pin_set()? {
             answer_to_select

--- a/src/command.rs
+++ b/src/command.rs
@@ -471,77 +471,37 @@ pub struct Register<'l> {
     pub credential: Credential<'l>,
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct Credential<'l> {
     pub label: &'l [u8],
-    pub kind: Option<oath::Kind>,
-    pub algorithm: Option<oath::Algorithm>,
-    pub digits: u8,
-    /// What we get here (inspecting the client app) may not be the raw K, but K' in HMAC lingo,
-    /// i.e., If secret.len() < block size (64B for Sha1/Sha256, 128B for Sha512),
-    /// then it's the hash of the secret.  Otherwise, it's the secret, padded to length
-    /// at least 14B with null bytes. This is of no concern to us, as is it does not
-    /// change the MAC.
-    ///
-    /// The 14 is a bit strange: RFC 4226, section 4 says:
-    /// "The algorithm MUST use a strong shared secret.  The length of the shared secret MUST be
-    /// at least 128 bits.  This document RECOMMENDs a shared secret length of 160 bits."
-    ///
-    /// Meanwhile, the client app just pads up to 14B :)
-    pub secret: Option<&'l [u8]>,
     pub touch_required: bool,
     pub encryption_key_type: EncryptionKeyType,
-    pub counter: Option<u32>,
-
-    pub login: Option<&'l [u8]>,
-    pub password: Option<&'l [u8]>,
-    pub metadata: Option<&'l [u8]>,
+    pub otp: Option<OtpCredentialData<'l>>,
+    pub password_safe: Option<PasswordSafeData<'l>>,
 }
 
-impl core::fmt::Debug for Credential<'_> {
-    fn fmt(
-        &self,
-        fmt: &mut core::fmt::Formatter<'_>,
-    ) -> core::result::Result<(), core::fmt::Error> {
-        fmt.debug_struct("Credential")
-            .field(
-                "label",
-                &core::str::from_utf8(self.label).unwrap_or("invalid UTF8 label"),
-            ) //(format!("{}", &hex_str!(&self.label))))
-            .field("kind", &self.kind)
-            .field("alg", &self.algorithm)
-            .field("digits", &self.digits)
-            .field("secret", &hex_str!(&self.secret.unwrap_or_default(), 4))
-            .field("touch", &self.touch_required)
-            .field("encryption", &self.encryption_key_type)
-            .field("counter", &self.counter)
-            .field(
-                "login",
-                &core::str::from_utf8(self.login.unwrap_or_default())
-                    .unwrap_or("invalid UTF8 login"),
-            )
-            .field(
-                "password",
-                &core::str::from_utf8(self.password.unwrap_or_default())
-                    .unwrap_or("invalid UTF8 password"),
-            )
-            .field(
-                "metadata",
-                &core::str::from_utf8(self.metadata.unwrap_or_default())
-                    .unwrap_or("invalid UTF8 metadata"),
-            )
-            .finish()
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct OtpCredentialData<'l> {
+    pub kind: oath::Kind,
+    pub algorithm: oath::Algorithm,
+    pub digits: u8,
+    pub secret: &'l [u8],
+    pub counter: Option<u32>,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub struct PasswordSafeData<'l> {
+    pub login: &'l [u8],
+    pub password: &'l [u8],
+    pub metadata: &'l [u8],
+}
+
+impl<'l> PasswordSafeData<'l> {
+    pub fn non_empty(&self) -> bool {
+        return !self.login.is_empty() || !self.password.is_empty() || !self.metadata.is_empty()
     }
 }
-
-// This is totally broken at the moment in flexiber
-//
-// #[derive(Decodable)]
-// pub struct SerializedPut<'l> {
-//     // #[tlv(simple="oath::Tag::Name as u8")]
-//     #[tlv(simple="0x71")]
-//     pub label: &'l [u8],
-// }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct Properties(u8);
@@ -685,33 +645,22 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for Register<'l> {
             }
             debug_now!("counter set to {:?}", &counter);
         }
+        let otp_data = Some(OtpCredentialData { kind, algorithm, digits, secret, counter });
 
-        let kind = Some(kind);
-        let algorithm = Some(algorithm);
-        let secret = Some(secret);
 
-        let mut credential = Credential {
-            label,
-            kind,
-            algorithm,
-            digits,
-            secret,
-            touch_required,
-            encryption_key_type,
-            counter,
-            // To be filled below
-            login: None,
-            password: None,
-            metadata: None,
-        };
+        let pws_data = {
+            let mut pws = PasswordSafeData {
+                login: &[],
+                password: &[],
+                metadata: &[],
+            };
 
-        let mut next_decoded: Option<TaggedSlice> = decoder.decode().ok();
-        while let Some(next) = next_decoded {
-            let tag = next.tag().embedding().number as u8;
-            let tag = oath::Tag::try_from(tag).unwrap();
-            let tag_data = next.as_bytes();
+            let mut next_decoded: Option<TaggedSlice> = decoder.decode().ok();
+            while let Some(next) = next_decoded {
+                let tag = next.tag().embedding().number as u8;
+                let tag = oath::Tag::try_from(tag).unwrap();
+                let tag_data = next.as_bytes();
 
-            match tag {
                 // Following should be caught before this loop
                 // Tag::Name => {},
                 // Tag::Key => {}
@@ -719,22 +668,36 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for Register<'l> {
                 // Tag::InitialMovingFactor => {}
                 // Tag::Algorithm => {}
                 // Tag::Touch => {}
-                Tag::PwsLogin => {
-                    credential.login = Some(tag_data);
+
+                match tag {
+                    Tag::PwsLogin => {
+                        pws.login = tag_data;
+                    }
+                    Tag::PwsPassword => {
+                        pws.password = tag_data;
+                    }
+                    Tag::PwsMetadata => {
+                        pws.metadata = tag_data;
+                    }
+                    _ => {
+                        // Unmatched tags should return error
+                        return Err(Status::IncorrectDataParameter);
+                    }
                 }
-                Tag::PwsPassword => {
-                    credential.password = Some(tag_data);
-                }
-                Tag::PwsMetadata => {
-                    credential.metadata = Some(tag_data);
-                }
-                _ => {
-                    // Unmatched tags should return error
-                    return Err(Status::IncorrectDataParameter);
-                }
+                next_decoded = decoder.decode().ok();
             }
-            next_decoded = decoder.decode().ok();
-        }
+            if pws.non_empty() {
+                Some(pws)
+            } else { None }
+        };
+
+        let credential = Credential {
+            label,
+            touch_required,
+            encryption_key_type,
+            otp: otp_data,
+            password_safe: pws_data,
+        };
 
         Ok(Register { credential })
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,8 +7,8 @@ use iso7816::Status::InstructionNotSupportedOrInvalid;
 use iso7816::{Data, Instruction, Status};
 use YKCommand::GetSerial;
 
-use crate::oath::{Kind, YKCommand};
 use crate::oath::Tag;
+use crate::oath::{Kind, YKCommand};
 use crate::{ensure, oath};
 
 const FAILED_PARSING_ERROR: Status = iso7816::Status::IncorrectDataParameter;
@@ -471,7 +471,6 @@ pub struct Register<'l> {
     pub credential: Credential<'l>,
 }
 
-
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]
 pub struct Credential<'l> {
     pub label: &'l [u8],
@@ -499,7 +498,7 @@ pub struct PasswordSafeData<'l> {
 
 impl<'l> PasswordSafeData<'l> {
     pub fn non_empty(&self) -> bool {
-        return !self.login.is_empty() || !self.password.is_empty() || !self.metadata.is_empty()
+        return !self.login.is_empty() || !self.password.is_empty() || !self.metadata.is_empty();
     }
 }
 
@@ -645,8 +644,13 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for Register<'l> {
             }
             debug_now!("counter set to {:?}", &counter);
         }
-        let otp_data = Some(OtpCredentialData { kind, algorithm, digits, secret, counter });
-
+        let otp_data = Some(OtpCredentialData {
+            kind,
+            algorithm,
+            digits,
+            secret,
+            counter,
+        });
 
         let pws_data = {
             let mut pws = PasswordSafeData {
@@ -688,7 +692,9 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for Register<'l> {
             }
             if pws.non_empty() {
                 Some(pws)
-            } else { None }
+            } else {
+                None
+            }
         };
 
         let credential = Credential {

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -71,13 +71,11 @@ impl Default for Credential {
 
 impl Credential {
     fn get_bytes_or_none_if_empty(x: &[u8]) -> Result<Option<ShortData>, ()> {
-        Ok(
-            if x.len() > 0 {
-                Some(ShortData::from_slice(x)?)
-            } else {
-                None
-            }
-        )
+        Ok(if x.len() > 0 {
+            Some(ShortData::from_slice(x)?)
+        } else {
+            None
+        })
     }
 
     pub fn try_from(credential: &command::Credential) -> Result<Self, ()> {


### PR DESCRIPTION
Reorganize runtime Credential structure for clearer implementation.

Instead of use of a flat Credential structure destined for use in the serialization (now called `CredentialFlat`), a Credential from command module was extended and reorganized to divide fields into separate types, and some of the verification checks were moved into the conversion code between these two, removing clutter from the actual operation execution.

Fixes #66 