### PR TITLE
Add metadata to list items

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -74,6 +74,22 @@ impl Default for CredentialFlat {
 }
 
 impl CredentialFlat {
+    pub fn get_properties_byte(&self) -> u8 {
+        let mut res: u8 = 0;
+        res |= if self.touch_required { 1 << 0 } else { 0 };
+        res |= if self.encryption_key_type.unwrap() == EncryptionKeyType::PinBased {
+            1 << 1
+        } else {
+            0
+        };
+        res |= if self.login.is_some() || self.password.is_some() {
+            1 << 2
+        } else {
+            0
+        };
+        res
+    }
+
     fn get_bytes_or_none_if_empty(x: &[u8]) -> Result<Option<ShortData>, ()> {
         Ok(if x.len() > 0 {
             Some(ShortData::from_slice(x)?)

--- a/src/state.rs
+++ b/src/state.rs
@@ -235,5 +235,5 @@ impl State {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CommandState {
-    ListCredentials(usize),
+    ListCredentials(usize, u8),
 }


### PR DESCRIPTION
Add metadata byte for the List command.

List command now accepts a single byte arguments, which denotes the requested encoding format for the list items.

Fixes #68 

Connected: https://github.com/Nitrokey/pynitrokey/pull/391