### PR TITLE
Review corrections for KeepassXC support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ iso7816 = "0.1"
 serde = { version = "1", default-features = false }
 trussed = { version = "0.1", features = ["clients-3"] }
 encrypted_container = { path = "components/encrypted_container" }
+block-padding = "0.3.3"
 
 # extension
 trussed-auth = "0.2.0"

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -13,7 +13,7 @@ use trussed::{client, syscall, try_syscall, types::PathBuf};
 
 use crate::calculate::hmac_challenge;
 use crate::command::CredentialData::HmacData;
-use crate::command::{Credential, EncryptionKeyType, ListCredentials, VerifyCode, YKGetHMAC};
+use crate::command::{Credential, EncryptionKeyType, ListCredentials, VerifyCode, YKGetHmac};
 use crate::credential::CredentialFlat;
 
 use crate::{
@@ -322,7 +322,7 @@ where
 
             Command::YKSerial => self.yk_serial(reply),
             Command::YKGetStatus => self.yk_status(reply),
-            Command::YKGetHMAC(req) => self.yk_hmac(req, reply),
+            Command::YKGetHmac(req) => self.yk_hmac(req, reply),
 
             Command::SendRemaining => self.send_remaining(reply),
             _ => Err(Status::ConditionsOfUseNotSatisfied),
@@ -1385,7 +1385,7 @@ where
         return Ok(());
     }
 
-    fn yk_hmac<const R: usize>(&mut self, req: YKGetHMAC, reply: &mut Data<{ R }>) -> Result {
+    fn yk_hmac<const R: usize>(&mut self, req: YKGetHmac, reply: &mut Data<{ R }>) -> Result {
         // Get HMAC slot command
         let credential = self
             .load_credential(req.get_credential_label()?)

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -13,7 +13,7 @@ use trussed::{client, syscall, try_syscall, types::PathBuf};
 
 use crate::calculate::hmac_challenge;
 use crate::command::CredentialData::HmacData;
-use crate::command::{Credential, EncryptionKeyType, ListCredentials, VerifyCode, YKGetHmac};
+use crate::command::{Credential, EncryptionKeyType, ListCredentials, VerifyCode, YkGetHmac};
 use crate::credential::CredentialFlat;
 
 use crate::{
@@ -320,9 +320,9 @@ where
             Command::SetPin(spin) => self.set_pin(spin, reply),
             Command::ChangePin(cpin) => self.change_pin(cpin, reply),
 
-            Command::YKSerial => self.yk_serial(reply),
-            Command::YKGetStatus => self.yk_status(reply),
-            Command::YKGetHmac(req) => self.yk_hmac(req, reply),
+            Command::YkSerial => self.yk_serial(reply),
+            Command::YkGetStatus => self.yk_status(reply),
+            Command::YkGetHmac(req) => self.yk_hmac(req, reply),
 
             Command::SendRemaining => self.send_remaining(reply),
             _ => Err(Status::ConditionsOfUseNotSatisfied),
@@ -1385,7 +1385,7 @@ where
         return Ok(());
     }
 
-    fn yk_hmac<const R: usize>(&mut self, req: YKGetHmac, reply: &mut Data<{ R }>) -> Result {
+    fn yk_hmac<const R: usize>(&mut self, req: YkGetHmac, reply: &mut Data<{ R }>) -> Result {
         // Get HMAC slot command
         let credential = self
             .load_credential(req.get_credential_label()?)

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,9 +7,7 @@ use iso7816::Status::InstructionNotSupportedOrInvalid;
 use iso7816::{Data, Instruction, Status};
 use YKCommand::GetSerial;
 
-use crate::oath::Tag;
-use crate::oath::Tag::Algorithm;
-use crate::oath::{Kind, YKCommand};
+use crate::oath::{Kind, Tag, YKCommand};
 use crate::{ensure, oath};
 
 const FAILED_PARSING_ERROR: Status = iso7816::Status::IncorrectDataParameter;
@@ -470,7 +468,7 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for Delete<'l> {
 impl<'l, const C: usize> TryFrom<&'l Data<C>> for ListCredentials {
     type Error = iso7816::Status;
     fn try_from(data: &'l Data<C>) -> Result<Self, Self::Error> {
-        let v = if data.len() > 0 { data[0] } else { 0 };
+        let v = if !data.is_empty() { data[0] } else { 0 };
         Ok(ListCredentials { version: v })
     }
 }
@@ -537,7 +535,7 @@ pub struct PasswordSafeData<'l> {
 
 impl<'l> PasswordSafeData<'l> {
     pub fn non_empty(&self) -> bool {
-        return !self.login.is_empty() || !self.password.is_empty() || !self.metadata.is_empty();
+        !self.login.is_empty() || !self.password.is_empty() || !self.metadata.is_empty()
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -104,6 +104,7 @@ impl<'l> TryFrom<&'l [u8]> for YkGetHmac<'l> {
         // PKCS#7 padding; possibly incompatible with Yubikey's PKCS#7 version, as it expects
         // the last byte to always be the padding byte value. See KeepassXC implementation comments
         // for the details.
+        // https://github.com/Nitrokey/keepassxc/blob/cf819e0a3f5664fb0e1705217dbebbdf704bdc34/src/keys/drivers/YubiKeyInterfacePCSC.cpp#L730
         // Everything works with the challenge length up to 63 bytes though, and YK implementation
         // would not handle more anyway, hence accepting this potential incompatibility.
         let challenge = Pkcs7::raw_unpad(data).map_err(|_| Status::IncorrectDataParameter)?;

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -91,7 +91,7 @@ impl CredentialFlat {
     }
 
     fn get_bytes_or_none_if_empty(x: &[u8]) -> Result<Option<ShortData>, ()> {
-        Ok(if x.len() > 0 {
+        Ok(if !x.is_empty() {
             Some(ShortData::from_slice(x)?)
         } else {
             None

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -123,15 +123,15 @@ pub enum Properties {
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum YKInstruction {
+pub enum YkInstruction {
     ApiRequest = 0x01,
     Status = 0x03,
 }
 
-impl TryFrom<u8> for YKInstruction {
+impl TryFrom<u8> for YkInstruction {
     type Error = iso7816::Status;
     fn try_from(byte: u8) -> Result<Self, Self::Error> {
-        use YKInstruction::*;
+        use YkInstruction::*;
         Ok(match byte {
             0x01 => ApiRequest,
             0x03 => Status,
@@ -142,17 +142,17 @@ impl TryFrom<u8> for YKInstruction {
 
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum YKCommand {
+pub enum YkCommand {
     GetSerial = 0x10,
     HmacSlot1 = 0x30,
     HmacSlot2 = 0x38,
 }
 
-impl TryFrom<u8> for YKCommand {
+impl TryFrom<u8> for YkCommand {
     type Error = Status;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        use YKCommand::*;
+        use YkCommand::*;
         Ok(match value {
             0x10 => GetSerial,
             0x30 => HmacSlot1,
@@ -162,19 +162,19 @@ impl TryFrom<u8> for YKCommand {
     }
 }
 
-impl From<YKCommand> for u8 {
-    fn from(val: YKCommand) -> Self {
+impl From<YkCommand> for u8 {
+    fn from(val: YkCommand) -> Self {
         val.as_u8()
     }
 }
 
-impl YKCommand {
+impl YkCommand {
     pub fn as_u8(&self) -> u8 {
         *self as u8
     }
 }
 
-impl PartialEq<u8> for YKCommand {
+impl PartialEq<u8> for YkCommand {
     fn eq(&self, other: &u8) -> bool {
         *self as u8 == *other
     }


### PR DESCRIPTION
Review corrections for KeepassXC support #64.

In the end the unpadding crate was used without modifications - it does not matter in this case, as payload bigger than 63 bytes can't be used anyway.