### PR TITLE
Allow to set maximum credentials count to store

### DIFF
--- a/examples/usbip.rs
+++ b/examples/usbip.rs
@@ -300,6 +300,7 @@ impl trussed_usbip::Apps<VirtClient, dispatch::Dispatch> for Apps {
             CustomStatus::ReverseHotpSuccess as u8,
             CustomStatus::ReverseHotpError as u8,
             [0x42, 0x42, 0x42, 0x42],
+            0xFFFF,
         );
         let otp = oath_authenticator::Authenticator::new(
             builder.build("otp", dispatch::BACKENDS),


### PR DESCRIPTION
Allow to set maximum credentials count to store through the Options struct.

Based on https://github.com/Nitrokey/trussed-secrets-app/pull/71
Fixes https://github.com/Nitrokey/trussed-secrets-app/issues/62