### PR TITLE
Ignore errors on factory reset, and start with the persistent storage

### DIFF
--- a/examples/usbip.rs
+++ b/examples/usbip.rs
@@ -300,14 +300,16 @@ impl trussed_usbip::Apps<VirtClient, dispatch::Dispatch> for Apps {
             CustomStatus::ReverseHotpSuccess as u8,
             CustomStatus::ReverseHotpError as u8,
             [0x42, 0x42, 0x42, 0x42],
-            0xFFFF,
+            u16::MAX,
         );
-        let secrets = secrets_app::Authenticator::new(
-            builder.build("otp", dispatch::BACKENDS),
-            options,
-        );
+        let secrets =
+            secrets_app::Authenticator::new(builder.build("secrets", dispatch::BACKENDS), options);
 
-        Self { fido, admin, secrets }
+        Self {
+            fido,
+            admin,
+            secrets,
+        }
     }
 
     fn with_ctaphid_apps<T>(

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -412,9 +412,10 @@ where
         self._extension_pin_factory_reset()?;
         self.state.runtime.reset();
 
-        // Remove potential missed remains for the extra care
-        // Ignore errors, if any
-        for loc in [self.options.location, Location::Volatile] {
+        // Remove potential missed remains for the extra care.
+        // Ignore errors, if any. Go over all locations.
+        // TODO Iterate directly over all the locations (e.g. using some macro crate), instead of specifying them here by hand
+        for loc in [Location::External, Location::Internal, Location::Volatile] {
             info_now!(":: reset - delete all keys and files in {:?}", loc);
             let _r1 = try_syscall!(self.trussed.delete_all(loc));
             let _r2 = try_syscall!(self

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -413,13 +413,14 @@ where
         self.state.runtime.reset();
 
         // Remove potential missed remains for the extra care
-        for loc in [Location::Volatile, self.options.location] {
+        // Ignore errors, if any
+        for loc in [self.options.location, Location::Volatile] {
             info_now!(":: reset - delete all keys and files in {:?}", loc);
-            try_syscall!(self.trussed.delete_all(loc)).map_err(|_| Status::NotEnoughMemory)?;
-            try_syscall!(self
+            let _r1 = try_syscall!(self.trussed.delete_all(loc));
+            let _r2 = try_syscall!(self
                 .trussed
-                .remove_dir_all(loc, trussed::types::PathBuf::new()))
-            .map_err(|_| Status::NotEnoughMemory)?;
+                .remove_dir_all(loc, trussed::types::PathBuf::new()));
+            debug_now!(":: reset - results {:?} {:?}", _r1, _r2);
         }
 
         debug_now!(":: reset over");


### PR DESCRIPTION
Update factory reset procedure to first delete data from the persistent storage, and ignore errors, if any are encountered.

Fixes #43 