### PR TITLE
Do not panic while listing credentials

### DIFF
--- a/src/credential.rs
+++ b/src/credential.rs
@@ -94,7 +94,14 @@ impl From<&CredentialFlat> for PropertiesByte {
         if cred.touch_required {
             res |= PropertiesByte::touch_required;
         }
-        if cred.encryption_key_type.unwrap() == EncryptionKeyType::PinBased {
+        if cred.encryption_key_type.is_none() {
+            warn_now!("encryption_key_type is not set");
+        }
+        if cred
+            .encryption_key_type
+            .unwrap_or(EncryptionKeyType::PinBased)
+            == EncryptionKeyType::PinBased
+        {
             res |= PropertiesByte::encrypted;
         }
         if cred.login.is_some() || cred.password.is_some() {


### PR DESCRIPTION
Do not panic while listing credentials when the used key type is not provided, but instead provide it from decrypting function.

Fixes https://github.com/Nitrokey/nitrokey-3-firmware/issues/300
Fixes https://github.com/Nitrokey/nitrokey-3-firmware/issues/296