### PR TITLE
force touch whenever a credential is deleted

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -434,6 +434,7 @@ where
     }
 
     fn delete(&mut self, delete: command::Delete<'_>) -> Result {
+        self.user_present()?;
         debug_now!("{:?}", delete);
         // It seems tooling first lists all credentials, so the case of
         // delete being called on a non-existing label hardly occurs.


### PR DESCRIPTION
This fixes https://github.com/Nitrokey/trussed-secrets-app/issues/92

It's my first try-out on the NitroKey firmware, open to feedback!

What I did was:

- See if I can get the fake NitroKey working over USB/IP as instructed here: https://github.com/Nitrokey/trussed-secrets-app/issues/92#issuecomment-1609962949
- Run the tests
- Apply the fix (I checked how the button press was used in other parts of the code)
- Re-run the tests, observe touch response in logs