### PR TITLE
Disallow credentials overwriting during registration

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -672,13 +672,13 @@ where
         Ok(())
     }
 
-    fn credential_with_label_exists(&mut self, label: &[u8]) -> bool {
+    fn credential_with_label_exists(&mut self, label: &[u8]) -> Result<bool> {
         let filename = self.filename_for_label(label);
         self.state.file_exists(&mut self.trussed, filename)
     }
 
     fn err_if_credential_with_label_exists(&mut self, label: &[u8]) -> Result {
-        match self.credential_with_label_exists(label) {
+        match self.credential_with_label_exists(label)? {
             false => Ok(()),
             true => Err(Status::OperationBlocked),
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -180,8 +180,17 @@ impl State {
         (Err(encrypted_container::Error::FailedDecryption), None)
     }
 
-    pub fn file_exists<T: FilesystemClient>(&mut self, trussed: &mut T, filename: PathBuf) -> bool {
-        try_syscall!(trussed.read_file(self.location, filename)).is_ok()
+    pub fn file_exists<T: FilesystemClient>(
+        &mut self,
+        trussed: &mut T,
+        filename: PathBuf,
+    ) -> crate::Result<bool> {
+        Ok(
+            try_syscall!(trussed.entry_metadata(self.location, filename))
+                .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?
+                .metadata
+                .is_some(),
+        )
     }
 
     pub fn try_read_file<T, O>(

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use crate::command::EncryptionKeyType;
 use cbor_smol::cbor_deserialize;
 use encrypted_container::EncryptedDataContainer;
+use trussed::client::FilesystemClient;
 use trussed::types::Message;
 use trussed::{
     syscall, try_syscall,
@@ -177,6 +178,10 @@ impl State {
             }
         }
         (Err(encrypted_container::Error::FailedDecryption), None)
+    }
+
+    pub fn file_exists<T: FilesystemClient>(&mut self, trussed: &mut T, filename: PathBuf) -> bool {
+        try_syscall!(trussed.read_file(self.location, filename)).is_ok()
     }
 
     pub fn try_read_file<T, O>(


### PR DESCRIPTION
Disallow credentials overwriting during registration
Require explicit removal with Delete() command from now on.

Fixes #55 