### PR TITLE
Support credential update

### DIFF
--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -818,7 +818,7 @@ where
     ///     - SecurityStatusNotSatisfied, if the encryption key cannot be fetched
     fn update_credential<const R: usize>(
         &mut self,
-        update_req: command::CredentialUpdate<'_>,
+        update_req: command::UpdateCredential<'_>,
         _reply: &mut Data<R>,
     ) -> Result {
         // DESIGN Get operation confirmation from user before proceeding

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -11,8 +11,8 @@ use core::time::Duration;
 use flexiber::EncodableHeapless;
 use heapless_bytes::Bytes;
 use iso7816::{Data, Status};
+use trussed::types::Location;
 use trussed::types::{KeyId, Message};
-use trussed::types::{Location, ShortData};
 use trussed::{self, client, syscall, try_syscall};
 
 use crate::calculate::hmac_challenge;
@@ -316,7 +316,6 @@ where
             Command::Register(register) => self.register(register),
             Command::Calculate(calculate) => self.calculate(calculate, reply),
             Command::GetCredential(get) => self.get_credential(get, reply),
-            Command::RenameCredential(rename) => self.rename_credential(rename, reply),
             Command::UpdateCredential(update) => self.update_credential(update, reply),
             #[cfg(feature = "calculate-all")]
             Command::CalculateAll(calculate_all) => self.calculate_all(calculate_all, reply),
@@ -860,61 +859,6 @@ where
                 .remove_file(self.options.location, filename_old))
             .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?;
         }
-        Ok(())
-    }
-
-    /// Rename credential
-    ///
-    /// Realized by loading FlatCredential object, changing its label,
-    /// writing under the new name and removing the previous file.
-    ///
-    /// Requires button confirmation before starting.
-    ///
-    /// returns: no data, except for the result code
-    /// Errors:
-    ///     - OperationBlocked if the new name is occupied already (checked by name hash)
-    ///     - NotFound, if the current credential can't be open (e.g. due to key not available) or deserialized
-    ///     - UnspecifiedNonpersistentExecutionError, if the old file cannot be removed, or serialization error
-    ///     - NotEnoughMemory, if new file cannot be written
-    ///     - SecurityStatusNotSatisfied, if the encryption key cannot be fetched
-    fn rename_credential<const R: usize>(
-        &mut self,
-        rename_req: command::RenameCredential<'_>,
-        _reply: &mut Data<R>,
-    ) -> Result {
-        // DESIGN Get operation confirmation from user before proceeding
-        self.user_present()?;
-
-        // DESIGN check if the target name is occupied already
-        self.err_if_credential_with_label_exists(rename_req.new_label)?;
-        if !self.credential_with_label_exists(rename_req.label)? {
-            return Err(Status::NotFound);
-        }
-
-        let credential = {
-            let mut c = self
-                .load_credential(rename_req.label)
-                .ok_or(Status::NotFound)?;
-            c.label =
-                ShortData::from_slice(rename_req.new_label).map_err(|_| Status::NotEnoughMemory)?;
-            c
-        };
-
-        // Serialize the credential (implicitly) and store it
-        let filename = self.filename_for_label(rename_req.new_label);
-        self.state.try_write_file(
-            &mut self.trussed,
-            filename,
-            &credential,
-            credential.encryption_key_type,
-        )?;
-
-        // Remove old file name
-        let filename_old = self.filename_for_label(rename_req.label);
-        try_syscall!(self
-            .trussed
-            .remove_file(self.options.location, filename_old))
-        .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?;
         Ok(())
     }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -53,7 +53,7 @@ pub enum Command<'l> {
     /// Get Credential data
     GetCredential(GetCredential<'l>),
     /// Update Credential
-    UpdateCredential(CredentialUpdate<'l>),
+    UpdateCredential(UpdateCredential<'l>),
     /// Return serial number of the device. Yubikey-compatible command. Used in KeepassXC.
     YkSerial,
     /// Return application's status. Yubikey-compatible command. Used in KeepassXC.
@@ -519,14 +519,14 @@ pub struct Credential<'l> {
 }
 
 #[derive(Clone, Copy, Eq, PartialEq, Debug, Default)]
-pub struct CredentialUpdate<'l> {
+pub struct UpdateCredential<'l> {
     pub label: &'l [u8],
     pub new_label: Option<&'l [u8]>,
     pub properties: Option<Properties>,
     pub password_safe: Option<PasswordSafeData<'l>>,
 }
 
-impl<'l, const C: usize> TryFrom<&'l Data<C>> for CredentialUpdate<'l> {
+impl<'l, const C: usize> TryFrom<&'l Data<C>> for UpdateCredential<'l> {
     type Error = Status;
     fn try_from(data: &'l Data<C>) -> Result<Self, Self::Error> {
         use flexiber::TaggedSlice;
@@ -544,7 +544,7 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for CredentialUpdate<'l> {
         }
         // end of obligatory fields parsing
 
-        let mut res = CredentialUpdate {
+        let mut res = UpdateCredential {
             label,
             ..Default::default()
         };
@@ -969,8 +969,8 @@ impl<'l, const C: usize> TryFrom<&'l iso7816::Command<C>> for Command<'l> {
                 (0x00, oath::Instruction::GetCredential, 0x00, 0x00) => {
                     Self::GetCredential(GetCredential::try_from(data)?)
                 }
-                (0x00, oath::Instruction::CredentialUpdate, 0x00, 0x00) => {
-                    Self::UpdateCredential(CredentialUpdate::try_from(data)?)
+                (0x00, oath::Instruction::UpdateCredential, 0x00, 0x00) => {
+                    Self::UpdateCredential(UpdateCredential::try_from(data)?)
                 }
                 (0x00, oath::Instruction::SendRemaining, 0x00, 0x00) => Self::SendRemaining,
                 _ => return Err(Status::InstructionNotSupportedOrInvalid),

--- a/src/command.rs
+++ b/src/command.rs
@@ -817,15 +817,22 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for Register<'l> {
                 // Tag::Algorithm => {}
                 // Tag::Touch => {}
 
+                fn nonempty_or_err(x: &[u8]) -> Result<Option<&[u8]>, Status> {
+                    if x.is_empty() {
+                        return Err(FAILED_PARSING_ERROR);
+                    }
+                    Ok(Some(x))
+                }
+
                 match tag {
                     Tag::PwsLogin => {
-                        pws.login = Some(tag_data);
+                        pws.login = nonempty_or_err(tag_data)?;
                     }
                     Tag::PwsPassword => {
-                        pws.password = Some(tag_data);
+                        pws.password = nonempty_or_err(tag_data)?;
                     }
                     Tag::PwsMetadata => {
-                        pws.metadata = Some(tag_data);
+                        pws.metadata = nonempty_or_err(tag_data)?;
                     }
                     _ => {
                         // Unmatched tags should return error

--- a/src/command.rs
+++ b/src/command.rs
@@ -52,8 +52,6 @@ pub enum Command<'l> {
     SendRemaining,
     /// Get Credential data
     GetCredential(GetCredential<'l>),
-    /// Rename Credential
-    RenameCredential(RenameCredential<'l>),
     /// Update Credential
     UpdateCredential(CredentialUpdate<'l>),
     /// Return serial number of the device. Yubikey-compatible command. Used in KeepassXC.
@@ -970,9 +968,6 @@ impl<'l, const C: usize> TryFrom<&'l iso7816::Command<C>> for Command<'l> {
                 }
                 (0x00, oath::Instruction::GetCredential, 0x00, 0x00) => {
                     Self::GetCredential(GetCredential::try_from(data)?)
-                }
-                (0x00, oath::Instruction::RenameCredential, 0x00, 0x00) => {
-                    Self::RenameCredential(RenameCredential::try_from(data)?)
                 }
                 (0x00, oath::Instruction::CredentialUpdate, 0x00, 0x00) => {
                     Self::UpdateCredential(CredentialUpdate::try_from(data)?)

--- a/src/command.rs
+++ b/src/command.rs
@@ -566,7 +566,8 @@ impl<'l, const C: usize> TryFrom<&'l Data<C>> for CredentialUpdate<'l> {
 
         let mut next_decoded: Option<TaggedSlice> = decoder.decode().ok();
         while let Some(next) = next_decoded {
-            next.encode_to_slice(&mut buf).unwrap();
+            next.encode_to_slice(&mut buf)
+                .map_err(|_| FAILED_PARSING_ERROR)?;
             let tag = buf[0];
             let tag = Tag::try_from(tag).map_err(|_| FAILED_PARSING_ERROR)?;
             let tag_data = next.as_bytes();

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -5,8 +5,8 @@
 
 use crate::command;
 use crate::command::{
-    CredentialData, CredentialUpdate, EncryptionKeyType, HmacData, OtpCredentialData,
-    PasswordSafeData,
+    CredentialData, EncryptionKeyType, HmacData, OtpCredentialData, PasswordSafeData,
+    UpdateCredential,
 };
 use crate::oath::{Algorithm, Kind};
 use iso7816::Status;
@@ -212,7 +212,7 @@ impl CredentialFlat {
     }
 
     /// Update credential fields with new values, and save
-    pub fn update_from(&mut self, update_req: CredentialUpdate) -> Result<(), Status> {
+    pub fn update_from(&mut self, update_req: UpdateCredential) -> Result<(), Status> {
         if let Some(new_label) = update_req.new_label {
             self.label = ShortData::from_slice(new_label).map_err(|_| Status::NotEnoughMemory)?;
         }

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -119,15 +119,12 @@ impl CredentialFlat {
     }
 
     fn get_bytes_if_not_empty_or_none(xo: Option<&[u8]>) -> Result<Option<ShortData>, ()> {
-        Ok(if let Some(x) = xo {
+        if let Some(x) = xo {
             if !x.is_empty() {
-                Some(ShortData::from_slice(x)?)
-            } else {
-                None
+                return Ok(Some(ShortData::from_slice(x)?));
             }
-        } else {
-            None
-        })
+        }
+        Ok(None)
     }
 
     fn get_ref_or_none(xo: &Option<ShortData>) -> Option<&[u8]> {

--- a/src/credential.rs
+++ b/src/credential.rs
@@ -118,9 +118,13 @@ impl CredentialFlat {
         res.bits()
     }
 
-    fn get_bytes_or_none(xo: Option<&[u8]>) -> Result<Option<ShortData>, ()> {
+    fn get_bytes_if_not_empty_or_none(xo: Option<&[u8]>) -> Result<Option<ShortData>, ()> {
         Ok(if let Some(x) = xo {
-            Some(ShortData::from_slice(x)?)
+            if !x.is_empty() {
+                Some(ShortData::from_slice(x)?)
+            } else {
+                None
+            }
         } else {
             None
         })
@@ -202,9 +206,9 @@ impl CredentialFlat {
         }
 
         if let Some(pass) = credential.password_safe {
-            cred.login = Self::get_bytes_or_none(pass.login)?;
-            cred.password = Self::get_bytes_or_none(pass.password)?;
-            cred.metadata = Self::get_bytes_or_none(pass.metadata)?;
+            cred.login = Self::get_bytes_if_not_empty_or_none(pass.login)?;
+            cred.password = Self::get_bytes_if_not_empty_or_none(pass.password)?;
+            cred.metadata = Self::get_bytes_if_not_empty_or_none(pass.metadata)?;
         }
 
         Ok(cred)
@@ -219,11 +223,11 @@ impl CredentialFlat {
             self.touch_required = p.touch_required();
         }
         if let Some(pws) = update_req.password_safe {
-            self.login = Self::get_bytes_or_none(pws.login)
+            self.login = Self::get_bytes_if_not_empty_or_none(pws.login)
                 .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?;
-            self.password = Self::get_bytes_or_none(pws.password)
+            self.password = Self::get_bytes_if_not_empty_or_none(pws.password)
                 .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?;
-            self.metadata = Self::get_bytes_or_none(pws.metadata)
+            self.metadata = Self::get_bytes_if_not_empty_or_none(pws.metadata)
                 .map_err(|_| Status::UnspecifiedNonpersistentExecutionError)?;
         }
         Ok(())

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -203,6 +203,7 @@ pub enum Instruction {
     SetPIN = 0xb4,
     GetCredential = 0xb5,
     RenameCredential = 0xb6,
+    CredentialUpdate = 0xb7,
 }
 
 impl TryFrom<u8> for Instruction {
@@ -225,6 +226,7 @@ impl TryFrom<u8> for Instruction {
             0xb4 => SetPIN,
             0xb5 => GetCredential,
             0xb6 => RenameCredential,
+            0xb7 => CredentialUpdate,
             _ => return Err(Self::Error::InstructionNotSupportedOrInvalid),
         })
     }

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -202,7 +202,6 @@ pub enum Instruction {
     ChangePIN = 0xb3,
     SetPIN = 0xb4,
     GetCredential = 0xb5,
-    RenameCredential = 0xb6,
     CredentialUpdate = 0xb7,
 }
 
@@ -225,7 +224,6 @@ impl TryFrom<u8> for Instruction {
             0xb3 => ChangePIN,
             0xb4 => SetPIN,
             0xb5 => GetCredential,
-            0xb6 => RenameCredential,
             0xb7 => CredentialUpdate,
             _ => return Err(Self::Error::InstructionNotSupportedOrInvalid),
         })

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -202,7 +202,7 @@ pub enum Instruction {
     ChangePIN = 0xb3,
     SetPIN = 0xb4,
     GetCredential = 0xb5,
-    CredentialUpdate = 0xb7,
+    UpdateCredential = 0xb7,
 }
 
 impl TryFrom<u8> for Instruction {
@@ -224,7 +224,7 @@ impl TryFrom<u8> for Instruction {
             0xb3 => ChangePIN,
             0xb4 => SetPIN,
             0xb5 => GetCredential,
-            0xb7 => CredentialUpdate,
+            0xb7 => UpdateCredential,
             _ => return Err(Self::Error::InstructionNotSupportedOrInvalid),
         })
     }


### PR DESCRIPTION
Add Initial support for the credential update
Makes RenameCredential command obsolete

Fixes #65 

pynitrokey support provided in https://github.com/Nitrokey/pynitrokey/pull/425