### PR TITLE
Prepare release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,33 @@
 
 ## [Unreleased](https://github.com/nitrokey/trussed-secrets-app/tree/HEAD)
 
-[Full Changelog](https://github.com/nitrokey/trussed-secrets-app/compare/v0.12.0...HEAD)
+[Full Changelog](https://github.com/nitrokey/trussed-secrets-app/compare/v0.13.0...HEAD)
+
+## [0.13.0](https://github.com/nitrokey/trussed-secrets-app/tree/v0.13.0) (2024-05-02)
+
+[Full Changelog](https://github.com/nitrokey/trussed-secrets-app/compare/v0.12.0...v0.13.0)
+
+**Added features**
+
+- Add support for credential update [\#97](https://github.com/Nitrokey/trussed-secrets-app/issues/97) and [\#99](https://github.com/Nitrokey/trussed-secrets-app/issues/99)
+- Prevent overwriting of credentials with `Register` [\#96](https://github.com/Nitrokey/trussed-secrets-app/issues/96)
 
 **Fixed bugs:**
 
 - Confirm Credential removal with a touch [\#92](https://github.com/Nitrokey/trussed-secrets-app/issues/92)
+- Require PIN confirmation for registering `ReverseHotp` credentials [\#114](https://github.com/Nitrokey/trussed-secrets-app/issues/114)
+
+**Removed**
+
+- Remove challenge-response implementation [\#83](https://github.com/Nitrokey/trussed-secrets-app/pull/83)
+
+**Changed**
+
+- Update documentation [\#100](https://github.com/Nitrokey/trussed-secrets-app/issues/100)
+- Improved logging and usbip simulation [\#102](https://github.com/Nitrokey/trussed-secrets-app/issues/102)
+- Fix compilation of fuzz targets [\#104](https://github.com/Nitrokey/trussed-secrets-app/issues/104)
+- Remove unused `interchange` dependency [\#105](https://github.com/Nitrokey/trussed-secrets-app/issues/105)
+- Use trussed-auth 0.3.0 [\#109](https://github.com/Nitrokey/trussed-secrets-app/issues/109)
 
 ## [v0.12.0](https://github.com/nitrokey/trussed-secrets-app/tree/v0.12.0) (2023-06-28)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.
 # unreleased upstream changes
 usbd-ctaphid = { git = "https://github.com/Nitrokey/usbd-ctaphid", tag = "v0.1.0-nitrokey.1" }
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.2" }
-serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }
+serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 
 # unreleased crates
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.3.0" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -64,7 +64,7 @@ trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey.
 
 # unreleased upstream changes
 ctaphid-dispatch = { git = "https://github.com/Nitrokey/ctaphid-dispatch", tag = "v0.1.1-nitrokey.2" }
-serde-indexed = { git = "https://github.com/sosthene-nitrokey/serde-indexed.git", rev = "5005d23cb4ee8622e62188ea0f9466146f851f0d" }
+serde-indexed = { git = "https://github.com/nitrokey/serde-indexed.git", tag = "v0.1.0-nitrokey.2" }
 
 # unreleased crates
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.3.0" }


### PR DESCRIPTION
Since the previous releases were marked as `rc`, non need to bump the `Cargo.toml`.